### PR TITLE
formatting dune files

### DIFF
--- a/src/commons/dune
+++ b/src/commons/dune
@@ -1,15 +1,5 @@
 (library
-  (name commons)
-  (public_name niagara-lang-lib.commons)
-  (wrapped false)
-  (libraries
-    ocamlgraph
-    calendar
-    sedlex
-    fmt
-    logs
-    logs.fmt
-    zarith
-  )
-)
-
+ (name commons)
+ (public_name niagara-lang-lib.commons)
+ (wrapped false)
+ (libraries ocamlgraph calendar sedlex fmt logs logs.fmt zarith))

--- a/src/compiler/dune
+++ b/src/compiler/dune
@@ -1,12 +1,4 @@
 (library
-  (name compiler)
-  (public_name niagara-lang-lib.compiler)
-  (libraries
-    calendar
-    commons
-    surface
-    dataflow
-    ocamlgraph
-    dot
-  )
-)
+ (name compiler)
+ (public_name niagara-lang-lib.compiler)
+ (libraries calendar commons surface dataflow ocamlgraph dot))

--- a/src/dataflow/dune
+++ b/src/dataflow/dune
@@ -1,11 +1,4 @@
-
 (library
-  (name dataflow)
-  (public_name niagara-lang-lib.dataflow)
-  (libraries
-    zarith
-    calendar
-    commons
-    surface
-  )
-)
+ (name dataflow)
+ (public_name niagara-lang-lib.dataflow)
+ (libraries zarith calendar commons surface))

--- a/src/exec/dune
+++ b/src/exec/dune
@@ -1,21 +1,20 @@
 (ocamllex testlex)
 
 (executable
-  (name main)
-  (package niagara-lang)
-  (public_name niagara)
-  (libraries
-    zarith
-    calendar
-    commons
-    cmdliner
-    grammar
-    surface
-    compiler
-    dataflow
-    interpreter
-    logs
-    fmt.tty
-    logs.cli
-    fmt.cli
-))
+ (name main)
+ (package niagara-lang)
+ (public_name niagara)
+ (libraries
+  zarith
+  calendar
+  commons
+  cmdliner
+  grammar
+  surface
+  compiler
+  dataflow
+  interpreter
+  logs
+  fmt.tty
+  logs.cli
+  fmt.cli))

--- a/src/grammar/dune
+++ b/src/grammar/dune
@@ -1,32 +1,20 @@
 (menhir
  (modules parser)
- (flags -v --table)
-)
+ (flags -v --table))
 
 (library
-  (name grammar)
-  (public_name niagara-lang-lib.grammar)
-  (libraries
-  zarith
-  calendar
-  commons
-  gen
-  surface
-  sedlex
-  menhirLib)
-  (preprocess
-   (pps sedlex.ppx))
-)
+ (name grammar)
+ (public_name niagara-lang-lib.grammar)
+ (libraries zarith calendar commons gen surface sedlex menhirLib)
+ (preprocess
+  (pps sedlex.ppx)))
 
 ; Grammar maintenance utilities
 
 (rule
  (with-stdout-to
   parser.messages.new
-  (run
-   menhir
-   %{dep:parser.mly}
-   --list-errors)))
+  (run menhir %{dep:parser.mly} --list-errors)))
 
 (rule
  (mode fallback)
@@ -36,11 +24,7 @@
 (rule
  (with-stdout-to
   parserErrors.ml
-  (run
-   menhir
-   %{dep:parser.mly}
-   --compile-errors
-   %{dep:parser.messages})))
+  (run menhir %{dep:parser.mly} --compile-errors %{dep:parser.messages})))
 
 (rule
  (with-stdout-to

--- a/src/interpreter/dune
+++ b/src/interpreter/dune
@@ -1,5 +1,12 @@
 (library
-  (name interpreter)
-  (public_name niagara-lang-lib.interpreter)
-  (libraries ocamlgraph calendar zarith commons compiler dataflow surface grammar)
-)
+ (name interpreter)
+ (public_name niagara-lang-lib.interpreter)
+ (libraries
+  ocamlgraph
+  calendar
+  zarith
+  commons
+  compiler
+  dataflow
+  surface
+  grammar))

--- a/src/surface/dune
+++ b/src/surface/dune
@@ -1,5 +1,4 @@
 (library
-  (name surface)
-  (public_name niagara-lang-lib.surface)
-  (libraries zarith calendar commons)
-)
+ (name surface)
+ (public_name niagara-lang-lib.surface)
+ (libraries zarith calendar commons))


### PR DESCRIPTION
OCamlformat requires dune files to not have useless newlines nowadays. Even though the compiler itself is yet to receive an .ocamlformat specification publically, it should be fine to make those slight changes.