### PR TITLE
Remove Operation/Advance Labels from the compiler

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -174,7 +174,7 @@ Une opération est une construction qui décrit une partie du flot de répartiti
 Il spécifie d'où part l'argent, où il arrive et en quel quantité. Exemple :
 
 ```niagara
-operation 'op simple'
+operation
 sur assiette rbd
 quotepart 20% vers prod
 ```
@@ -194,7 +194,7 @@ de définir le transfert d'une somme fixe, le plus souvent sous réserve de
 conditions spécifiques.
 
 ```niagara
-operation 'transfert fixe'
+operation
 par prod
 bonus 5000$ vers scenariste
 ```
@@ -210,7 +210,7 @@ Notez l'apparition d'un nouveau mot-clé dans cet exemple : `par`. Tout comme
 Plusieurs opérateurs peuvent être fournis dans une même opération :
 
 ```niagara
-operation 'more parties'
+operation
 sur assiette rbd
 quotepart 20% vers prod
 quotepart 10% vers sofica1
@@ -227,7 +227,7 @@ syntaxiquement à chaque opérateur présent. Il est également possible de
 spécifier une destination par défaut pour tous les opérateurs :
 
 ```niagara
-operation 'op simple 2' vers prod
+operation vers prod
 sur assiette rbd
 quotepart 20%
 ```
@@ -246,7 +246,7 @@ cascade et utilisé comme source d'opérations. Il est également possible de
 créer des assiettes intermédiaires à la volée comme destination :
 
 ```niagara
-operation 'base rnpp'
+operation
 sur assiette rbd
 quotepart 20% vers distrib
 quotepart 80% vers assiette rnpp
@@ -263,7 +263,7 @@ Jusqu'à présent les opérateurs n'utilisaient que des valeurs littérales, mai
 est possible de définir des formules plus complexes :
 
 ```niagara
-operation 'proportionnelle' vers acteur1
+operation vers acteur1
 par prod
 bonus entreeSalles * 0.90$
 ```
@@ -319,11 +319,11 @@ l'instant courant : deux opérateurs postposés `total` et `courant`
 respectivement.
 
 ```niagara
-operation 'delta' vers acteur1
+operation vers acteur1
 par prod
 bonus 1$ * entreesSalle courant
 
-operation 'total' vers acteur1
+operation vers acteur1
 par prod
 bonus 1$ * entreesSalle total
 ```
@@ -342,7 +342,7 @@ valeurs prendront leur forme à l'instant courant. L'exemple suivant est
 strictement équivalent à l'opération `'delta'` au dessus :
 
 ```niagara
-operation 'delta bis' vers acteur1
+operation vers acteur1
 par prod
 bonus 1$ * entreesSalle
 ```
@@ -381,7 +381,7 @@ Pour conditionner une attribution dans une opération, on définit la condition
 avant les opérateurs d'attribution :
 
 ```niagara
-operation 'com' vers distrib
+operation vers distrib
 sur assiette rbd
 avant evenement recupCom
   quotepart 90%
@@ -403,7 +403,7 @@ Il est également possible d'écrire des formules d'événement directement dans
 condition sans l'avoir préalablement déclaré :
 
 ```niagara
-operation 'evenement anonyme'
+operation
 par prod
 quand entreeSalles = 100000
  bonus 1000$ vers acteur1
@@ -413,7 +413,7 @@ Les conditions peuvent être imbriquées les une dans les autres en utilisant de
 parenthèses :
 
 ```niagara
-operation 'conditions imbriquées' vers distrib
+operation vers distrib
 sur assiette rbd
 avant evenement a (
  apres evenement b
@@ -428,7 +428,7 @@ que `a` l'est aussi, alors cette opération ne fait aucune attribution.
 Un opération peut avoir une série de conditions :
 
 ```niagara
-operation 'conditions multiples' vers distrib
+operation vers distrib
 sur assiette rbd
 avant evenement a
  quotepart 20%
@@ -451,7 +451,7 @@ On peut clarifier le comportement de cette opération en en écrivant une avec d
 conditions imbriquées :
 
 ```niagara
-operation 'conditions multiples strict' vers distrib
+operation vers distrib
 sur assiette rbd
 avant evenement b (
  avant evenement a
@@ -468,7 +468,7 @@ S'il existe des conditions, elle seront appliquées de la même manière à tous
 opérateurs :
 
 ```niagara
-operation 'operateurs multiples'
+operation
 par prod
 quand evenement e1
  bonus 200$ vers celebrite1
@@ -528,7 +528,7 @@ Un fois déclarés, les contextes peuvent être spécifié sur des opération po
 restreindre leur champs d'application :
 
 ```niagara
-operation 'tv france'
+operation
 pour Support(TV)
 pour Territoire(France)
 sur assiette rbd
@@ -563,7 +563,7 @@ contexte sur une assiette doivent se refléter sur les assiettes qui lui sont
 réattribuées.
 
 ```niagara
-operation 'tv sofica'
+operation
 pour Support(TV)
 sur assiette rnpp
 quotepart 10% vers sofica
@@ -573,7 +573,7 @@ Cette opération contraint l'assiette `rnpp` a être distincte entre le support 
 et les autres. Soit l'opération suivante, en amont de `rnpp` :
 
 ```niagara
-operation 'tv monde'
+operation
 sur assiette rbd
 quotepart 20% vers distrib
 quotepart 80% vers assiette rnpp
@@ -586,7 +586,7 @@ les autres, puisqu'elle verse dans une assiette qui fait cette distinction.
 À noter que si par ailleurs on a :
 
 ```niagara
-operation 'salle france'
+operation
 pour Support(Salles)
 pour Territoire(France)
 sur assiette rbd
@@ -613,7 +613,7 @@ un contexte sur une valeur précise. Le langage propose une notation pour la
 contextualisation locale :
 
 ```niagara
-operation 'rem entreesSalles' vers acteur1
+operation vers acteur1
 par prod
 bonus entreesSalles(France) * 0.20$
 bonus entreeSalles(Belgique, Etranger) * 0.15$
@@ -666,7 +666,7 @@ il est possible d´étiqueter l'utilisation de partenaire pour identifier et fai
 référence à des couloirs spécifiques :
 
 ```niagara
-operation 'special treatment' vers distrib[special]
+operation vers distrib[special]
 par prod[distribBonus]
 bonus 5000$
 ```
@@ -684,7 +684,7 @@ cela fait référence à la somme des différent couloirs.
 La rétrocession est une opération de transfert d'un part d'une valeur ciblée :
 
 ```niagara
-operation 'return' vers distrib
+operation vers distrib
 par prod
 retrocession 20% sur assiette rnpp
 ```
@@ -692,7 +692,7 @@ retrocession 20% sur assiette rnpp
 Cet opération est une autre manière d'exprimer le code suivant :
 
 ```niagara
-operation 'return' vers distrib
+operation vers distrib
 par prod
 bonus assiette rnpp * 20%
 ```

--- a/examples/initialization.nga
+++ b/examples/initialization.nga
@@ -7,7 +7,7 @@ entree entrees type entier
 assiette calculee rbd
 : 5$ * entrees
 
-operation 'com'
+operation
 sur assiette rbd
 quotepart 20% opposable 10% envers sofica par prod[opp] vers distrib
 
@@ -17,14 +17,14 @@ valeur observable palier : prod - 100$
 
 evenement seuil atteint quand palier = 800$
 
-operation 'rep'
+operation
 sur assiette rnpp
 avant evenement seuil
 quotepart 10% vers distrib
 apres evenement seuil
 quotepart 30% vers distrib
 
-operation 'rnpp'
+operation
 sur assiette rnpp
 quotepart 20% vers sofica
 

--- a/examples/non_opp_qp.nga
+++ b/examples/non_opp_qp.nga
@@ -4,12 +4,12 @@ acteur prod
 
 entree assiette rbd
 
-operation 'com'
+operation
 sur assiette rbd
 quotepart 20% non opposable vers distrib
 quotepart reste vers assiette rnpp
 
-operation 'sof'
+operation
 sur assiette rnpp
 quotepart 40% vers sofica
 

--- a/examples/observable.nga
+++ b/examples/observable.nga
@@ -16,7 +16,7 @@ assiette calculee rbd
 pour Territoire(Belgique,Etranger)
 : 10$ * entrees
 
-operation 'com'
+operation
 pour Territoire(Belgique)
 sur assiette rbd
 quotepart 20% vers distrib
@@ -27,7 +27,7 @@ valeur observable palier : prod - 100$
 
 evenement seuil atteint quand palier = 800$
 
-operation 'rep'
+operation
 sur assiette rnpp
 avant evenement seuil
 quotepart 10% vers distrib

--- a/examples/opposition.nga
+++ b/examples/opposition.nga
@@ -4,7 +4,7 @@ acteur sofica
 
 entree assiette rbd
 
-operation 'com'
+operation
 sur assiette rbd
 quotepart 40% opposable 20% envers sofica par prod[sofopp] vers distrib
 quotepart reste vers assiette rnc
@@ -12,7 +12,7 @@ quotepart reste vers assiette rnc
 evenement recup_frais atteint quand
   distrib[frais] = 2400$ opposable 1800$ envers sofica par prod[sofopp]
 
-operation 'frais'
+operation
 sur assiette rnc
 avant evenement recup_frais
  quotepart 100% vers distrib[frais]
@@ -21,7 +21,7 @@ defaut sur assiette rnc vers assiette rnpp
 
 evenement recup_sofica atteint quand sofica[recup] = 12000$
 
-operation 'part sofica'
+operation
 sur assiette rnpp
 avant evenement recup_sofica
  quotepart 20% vers sofica[recup]

--- a/examples/sur_un_nuage.nga
+++ b/examples/sur_un_nuage.nga
@@ -55,7 +55,7 @@ atteint quand distributeur_du_desert[frais_edition] = frais_edition_distributeur
 evenement recuperation_minimum_garanti
 atteint quand distributeur_du_desert[minimum_garanti] = minimum_garanti_distributeur_du_desert
 
-operation 'commission salle vers distributeur'
+operation
 pour Territoire(France)
 pour Support(Salle)
 pour Secteur(Commercial)
@@ -67,7 +67,7 @@ apres evenement seuil_100000_entrees
 quotepart 20% vers distributeur_du_desert
 quotepart 80% vers assiette recette_nette_commission_distributeur
 
-operation 'commission non commercial vers distributeur'
+operation
 pour Territoire(France)
 pour Support(Salle)
 pour Secteur(Non_commercial)
@@ -75,14 +75,14 @@ sur assiette recette_brute_distributeur
 quotepart 50% vers distributeur_du_desert[commission_cinema_non_commerciale]
 quotepart 50% vers assiette recette_nette_commission_distributeur
 
-operation 'commission video vers distributeur'
+operation
 pour Territoire(France)
 pour Support(Video)
 sur assiette recette_brute_distributeur
 quotepart 25% vers distributeur_du_desert[commission_video]
 quotepart 75% vers assiette recette_nette_commission_distributeur
 
-operation 'recuperation frais edition vers distributeur'
+operation
 pour Territoire(France)
 pour Support(Salle, Video)
 sur assiette recette_nette_commission_distributeur
@@ -91,7 +91,7 @@ quotepart 100% vers distributeur_du_desert[frais_edition]
 apres evenement recuperation_frais_edition_distributeur
 quotepart 100% vers assiette recette_nette_part_producteur
 
-operation 'recuperation minimum garanti distributeur'
+operation
 pour Territoire(France)
 pour Support(Salle, Video)
 sur assiette recette_nette_part_producteur
@@ -109,7 +109,7 @@ defaut sur assiette recette_nette_part_producteur(France) vers les_productions_d
 evenement recuperation_frais_edition_scorpion
 atteint quand vendeur_scorpion[frais_edition_vendeur_scorpion] = frais_edition_vendeur_scorpion
 
-operation 'commission vers vendeur'
+operation
 pour Territoire(Etranger)
 pour tout Support
 sur assiette recette_brute_vendeur
@@ -120,7 +120,7 @@ apres evenement recuperation_frais_edition_scorpion
 quotepart 15% vers vendeur_scorpion[commission_vendeur]
 quotepart 85% vers assiette recette_nette_commission_vendeur
 
-operation 'recuperation frais d éditions vers vendeur'
+operation
 pour Territoire(Etranger)
 sur assiette recette_nette_commission_vendeur
 avant evenement recuperation_frais_edition_scorpion
@@ -135,7 +135,7 @@ defaut sur assiette recette_nette_part_producteur(Etranger) vers les_productions
 # le producteur prend une commission sur les ventes TV ou SVOD
 # ce qui reste va dans l'assiette recette_nette_part_producteur
 
-operation 'commission sur vente tv vers production'
+operation
 pour Support(TV,SVOD)
 pour Territoire(France)
 sur assiette vente_tvsvod
@@ -146,7 +146,7 @@ quotepart 80% vers assiette recette_nette_part_producteur
 # CONTRAT BARBIE
 # barbie prend 20% de toutes les recette_nette_part_producteur
 
-operation 'interessement sur les recettes du film'
+operation
 pour tout Support
 pour tout Territoire
 pour Secteur(Commercial)
@@ -156,7 +156,7 @@ quotepart 20% vers barbie[interessement]
 #barbie prend un bonus de 10000€ à 100000 entrees
 #ce bonus est donné par le producteur
 
-operation 'bonus sur le nombre d entrees'
+operation
 par les_productions_du_chameau[bonus_nombre_entrees]
 quand evenement seuil_100000_entrees
 bonus 10000$ vers barbie[bonus_nombre_entrees]
@@ -169,21 +169,22 @@ bonus 10000$ vers barbie[bonus_nombre_entrees]
 evenement recup_risque_prod
 atteint quand les_productions_du_chameau = risque_prod
 
-operation 'part copro sur france'
+operation
 pour Territoire(France)
 pour Support(Salle, Video)
 sur assiette recette_nette_part_producteur
 apres evenement recuperation_minimum_garanti
 quotepart 10% vers dromadaire_film[france]
 
-operation 'part copro sur tv '
+operation
 pour Territoire(France)
 pour Support(TV, SVOD)
 sur assiette recette_nette_part_producteur
 quotepart 40% vers dromadaire_film[tv_svod]
 
-operation 'part copro sur etranger'
+operation
 pour Territoire(Etranger)
 sur assiette recette_nette_part_producteur
 apres evenement recup_risque_prod
 quotepart 20% vers dromadaire_film[etranger]
+

--- a/examples/weird_shapes.nga
+++ b/examples/weird_shapes.nga
@@ -5,34 +5,34 @@ entree assiette a
 entree assiette k
 acteur g
 
-operation 'ab' vers assiette b
+operation vers assiette b
 pour Y(Y1,Y2)
 sur assiette a
 quotepart 100%
 
-operation 'ac' vers assiette c
+operation vers assiette c
 pour Y(Y2,Y3)
 sur assiette a
 quotepart 100%
 
-operation 'bg' vers g
+operation vers g
 pour X(X1)
 pour Y(Y1,Y2)
 sur assiette b
 quotepart 100%
 
-operation 'cg1' vers g
+operation vers g
 pour Y(Y3)
 sur assiette c
 quotepart 100%
 
-operation 'cg2' vers g
+operation vers g
 pour X(X2)
 pour Y(Y2)
 sur assiette c
 quotepart 100%
 
-operation 'kg1' vers g
+operation vers g
 pour X(X1)
 pour Y(Y1)
 sur assiette k

--- a/src/commons/varInfo.ml
+++ b/src/commons/varInfo.ml
@@ -20,7 +20,6 @@ type origin =
   | RisingEvent of Variable.t
   | ContextSpecialized of { origin : Variable.t; context : Context.Group.t }
   | OperationDetail of {
-      label : string option;
       op_kind : op_kind;
       condition : event_loc;
       source : Variable.t;
@@ -118,7 +117,7 @@ let print fmt t =
   | RisingEvent v -> fprintf fmt "^%d" (Variable.uid v)
   | ContextSpecialized { origin; context } ->
     fprintf fmt "%d(%a)" (Variable.uid origin) Context.Group.print context
-  | OperationDetail { label = _; source; target; op_kind; condition = _ } ->
+  | OperationDetail { source; target; op_kind; condition = _ } ->
     fprintf fmt "[%d->%d]%s" (Variable.uid source) (Variable.uid target)
       (match op_kind with
        | Quotepart _ -> "%"

--- a/src/commons/varInfo.mli
+++ b/src/commons/varInfo.mli
@@ -20,7 +20,6 @@ type origin =
   | RisingEvent of Variable.t
   | ContextSpecialized of { origin : Variable.t; context : Context.Group.t }
   | OperationDetail of {
-      label : string option;
       op_kind : op_kind;
       condition : event_loc;
       source : Variable.t;

--- a/src/compiler/contextualize.ml
+++ b/src/compiler/contextualize.ml
@@ -861,7 +861,6 @@ let operation acc (op : operation_decl) =
   in
   acc,
   {
-    ctx_op_label = op.op_label;
     ctx_op_default_dest = default_dest;
     ctx_op_source = source;
     ctx_op_guarded_redistrib = g_redist;
@@ -882,9 +881,6 @@ let event_decl acc (e : event_decl) =
 let constant acc (c : const_decl) =
   let t = Literal.type_of c.const_value in
   Acc.register_const acc c.const_name t c.const_value
-
-let advance _acc (_a : advance_decl) = Report.raise_error "no more advance"
-
 let comp_pool acc (p : comp_pool_decl) =
   let acc, pool =
     match Acc.find_pool_opt acc p.comp_pool_name with
@@ -965,7 +961,6 @@ let declaration acc (decl : source declaration) =
     let acc, ctx_deficit_provider = find_holder_as_source acc d.deficit_provider in
     let acc = Acc.add_deps_from acc (fst ctx_deficit_provider) [fst ctx_deficit_pool] in
     Acc.add_program_decl acc (DVarDeficit { ctx_deficit_pool; ctx_deficit_provider})
-  | DHolderAdvance a -> advance acc a
 
 let program (Source prog : source program) : contextualized program =
   let acc = Acc.empty in

--- a/src/compiler/equationalize.ml
+++ b/src/compiler/equationalize.ml
@@ -22,7 +22,6 @@ type expr_with_opps = expr * opposed_expr
 module Acc = struct
 
 type flat_op = {
-  flat_label : string option;
   flat_expr : expr;
   flat_src : Variable.t;
   flat_cond : Condition.t;
@@ -217,10 +216,10 @@ let lift_event t (event, opp_evs : expr_with_opps)
   in
   t, v
 
-let register_part t ~(label : string option) ~(act : Condition.t) ~(src : Variable.t)
+let register_part t ~(act : Condition.t) ~(src : Variable.t)
     ~(dest : Variable.t) ~(main_event : VarInfo.event_loc)
     (part : Repartition.part_or_def) =
-  let share = Repartition.{ label; dest; part; condition = act; main_event } in
+  let share = Repartition.{ dest; part; condition = act; main_event } in
   let repartitions =
     Variable.Map.update src (function
         | None -> Some [ share ]
@@ -246,12 +245,11 @@ let register_deficit t ~(act : Condition.t) ~(provider : Variable.t)
     ~(pool : Variable.t) =
   register_part t ~act ~src:pool ~dest:provider Deficit
 
-let register_flat ~(label : string option) t
+let register_flat t
     ~(act : Condition.t) ~(src : Variable.t)
     ~(dest : Variable.t) ~(main_event : VarInfo.event_loc)
     (expr, opps : expr_with_opps) =
   let flat = {
-    flat_label = label;
     flat_src = src;
     flat_expr = expr;
     flat_cond = act;
@@ -412,15 +410,14 @@ let group_productions ~produce ~aggr_var t ops =
     t, (agv, cond)
 
 let convert_repartitions t =
-  let register_part t src ({ label; condition; part; dest; main_event }
+  let register_part t src ({condition; part; dest; main_event }
                            : Repartition.opposable_part Repartition.share) =
     let part, opposed = part in
     let t, ov = create_var_from t dest (fun i ->
         { i with
           kind = Intermediary;
           origin = OperationDetail
-              { label;
-                op_kind = Quotepart part;
+              { op_kind = Quotepart part;
                 source = src;
                 target = dest;
                 condition = main_event
@@ -446,12 +443,11 @@ let convert_repartitions t =
       non_opp_shares =
     match def_share with
     | None -> t
-    | Some { label; dest; condition; part; main_event } ->
+    | Some {dest; condition; part; main_event } ->
       let t, ov = create_var_from t dest (fun i ->
           { i with
             kind = Intermediary;
             origin = OperationDetail {
-                label;
                 condition = main_event;
                 op_kind = Deficit part;
                 source = dest;
@@ -574,8 +570,7 @@ let convert_repartitions t =
                 { i with
                   kind = Intermediary;
                   origin = OperationDetail
-                      { label = share.label;
-                        op_kind = Default share.part;
+                      { op_kind = Default share.part;
                         source = src;
                         target = share.dest;
                         condition = share.main_event
@@ -605,7 +600,6 @@ let convert_flats t =
   let produce_op dest src t flat =
     let origin : VarInfo.origin =
       OperationDetail {
-        label = flat.flat_label;
         condition = flat.flat_main_event;
         op_kind = Bonus (vars_of_expr flat.flat_expr);
         source = src;
@@ -968,8 +962,7 @@ let rec translate_event acc (eexpr : Ast.contextualized Ast.event_expr) =
     acc, e
   | EventDisj _ -> assert false
 
-let translate_redistribution ~(label : string option)
-    acc ~(ctx : Context.Group.t)
+let translate_redistribution acc ~(ctx : Context.Group.t)
     ~(act : Condition.t)
     ~(src : Variable.t) ~(dest : Ast.contextualized_variable)
     (redist : Ast.contextualized Ast.redistribution) =
@@ -1000,11 +993,11 @@ let translate_redistribution ~(label : string option)
           (target, opp_part, provider)::opps)
         fopps []
     in
-    Acc.register_redist ~label acc ~act ~src ~dest ~non_opp part opps
+    Acc.register_redist acc ~act ~src ~dest ~non_opp part opps
   | Flat f ->
     let acc, e = translate_formula ~ctx ~view:AtInstant acc f in
-    Acc.register_flat ~label acc ~act ~src ~dest e
-  | Default -> Acc.register_default ~label acc ~act ~src ~dest
+    Acc.register_flat acc ~act ~src ~dest e
+  | Default -> Acc.register_default acc ~act ~src ~dest
 
 let translate_redist_w_dest acc
     ~(ctx : Context.Group.t) ~(act : Condition.t)
@@ -1038,13 +1031,13 @@ let conds_of_event ~act (evt : Variable.t) =
   condt, condf
 
 let translate_redists acc
-    ~(label : string option) ~(ctx : Context.Group.t)
+    ~(ctx : Context.Group.t)
     ~(act : Condition.t) ~(src : Variable.t)
     ~(def_dest : Ast.contextualized_variable option)
     ~(main_event : VarInfo.event_loc)
     (rs : Ast.contextualized Ast.redistrib_with_dest list) =
   List.fold_left
-    (translate_redist_w_dest ~label ~ctx ~act ~src ~def_dest ~main_event)
+    (translate_redist_w_dest ~ctx ~act ~src ~def_dest ~main_event)
     acc rs
 
 let rec translate_guarded_obj : type obj. Acc.t
@@ -1095,7 +1088,7 @@ let translate_operation acc (o : Ast.ctx_operation_decl) =
   Context.shape_fold (fun acc ctx ->
       let acc, src = Acc.get_derivative_var acc (fst o.ctx_op_source) ctx in
       let redist_process =
-        translate_redists ~label:(Some o.ctx_op_label)
+        translate_redists
           ~src ~def_dest:o.ctx_op_default_dest
       in
       translate_guarded_obj acc redist_process
@@ -1126,7 +1119,7 @@ let translate_default acc (d : Ast.ctx_default_decl) =
         | ContextVar [dest] -> dest
         | _ -> Report.raise_error "destination derivation should have been unique"
       in
-      Acc.register_default ~label:None acc ~act:Condition.always
+      Acc.register_default acc ~act:Condition.always
         ~src ~dest ~main_event:NoEvent)
     acc source_local_shape
 
@@ -1141,7 +1134,7 @@ let translate_deficit acc (d : Ast.ctx_deficit_decl) =
   let pool_local_shape = shape_of_ctx_var acc d.ctx_deficit_pool in
   Context.shape_fold (fun acc ctx ->
       let acc, pool = Acc.get_derivative_var acc (fst d.ctx_deficit_pool) ctx in
-      Acc.register_deficit ~label:None acc ~act:Condition.always
+      Acc.register_deficit acc ~act:Condition.always
         ~provider ~pool ~main_event:NoEvent)
     acc pool_local_shape
 

--- a/src/dataflow/opposition.ml
+++ b/src/dataflow/opposition.ml
@@ -272,7 +272,7 @@ let origin_variant acc env (var : Variable.t) (vorigin : VarInfo.origin) =
     LabelOfPartner { partner = variant_if_exists partner; label }
   | Cumulative v -> Cumulative (variant_if_exists v)
   | OpposingVariant { variant; _ } -> variant
-  | OperationDetail { label; op_kind; source; target; condition } ->
+  | OperationDetail { op_kind; source; target; condition } ->
     let op_kind =
       match op_kind with
       | Quotepart p -> VarInfo.Quotepart (convert_part p)
@@ -288,7 +288,7 @@ let origin_variant acc env (var : Variable.t) (vorigin : VarInfo.origin) =
       | After e -> After (variant_if_exists e)
       | When e -> When (variant_if_exists e)
     in
-    OperationDetail { label; op_kind; source; target; condition }
+    OperationDetail {op_kind; source; target; condition }
   | LocalValuation { target; deps } ->
     let target = variant_if_exists target in
     let deps = Variable.Set.map variant_if_exists deps in

--- a/src/dataflow/repartition.ml
+++ b/src/dataflow/repartition.ml
@@ -13,7 +13,6 @@ type part_or_def =
   | Deficit
 
 type 'a share = {
-  label : string option;
   main_event : VarInfo.event_loc;
   dest : Variable.t;
   part : 'a;
@@ -180,7 +179,6 @@ let resolve_fullness_exn (rep : part_or_def t) =
           R.Map.fold (fun _p -> Condition.disj) ds Condition.never
         in
         let share = {
-          label = def_share.label;
           dest = def_share.dest;
           condition; part = ds;
           main_event = def_share.main_event
@@ -199,8 +197,7 @@ let resolve_fullness_exn (rep : part_or_def t) =
         R.Map.fold (fun _p -> Condition.disj) ds Condition.never
       in
       let gd_share =
-        { label = share.label;
-          dest = share.dest;
+        { dest = share.dest;
           condition;
           part = ds;
           main_event = share.main_event
@@ -225,7 +222,6 @@ let resolve_fullness_exn (rep : part_or_def t) =
         R.Map.fold (fun _p -> Condition.disj) ds Condition.never
       in
       let deficit_share = {
-        label = share.label;
         dest = share.dest;
         condition; part = ds;
         main_event = share.main_event
@@ -235,19 +231,19 @@ let resolve_fullness_exn (rep : part_or_def t) =
   check_fullness parts;
   {
     parts =
-      List.filter_map (fun { label; part; dest; condition; main_event } ->
+      List.filter_map (fun {part; dest; condition; main_event } ->
           match part with
           | Part { part; non_opp = false } ->
-            Some { label; part; dest; condition; main_event }
+            Some { part; dest; condition; main_event }
           | _ -> None)
         rep;
     defaults = (Option.to_list global_default) @ local_defaults;
     deficits = deficit;
     non_opp_parts =
-      List.filter_map (fun { label; part; dest; condition; main_event } ->
+      List.filter_map (fun { part; dest; condition; main_event } ->
           match part with
           | Part { part; non_opp = true } ->
-            Some { label; part; dest; condition; main_event }
+            Some { part; dest; condition; main_event }
           | _ -> None)
         rep;
   }

--- a/src/dataflow/repartition.mli
+++ b/src/dataflow/repartition.mli
@@ -13,7 +13,6 @@ type part_or_def =
   | Deficit
 
 type 'a share = {
-  label : string option;
   main_event : VarInfo.event_loc;
   dest : Variable.t;
   part : 'a;

--- a/src/grammar/lexer.ml
+++ b/src/grammar/lexer.ml
@@ -35,11 +35,9 @@ let keywords =
     "constante", CONSTANTE;
     "defaut", DEFAUT;
     "deficit", DEFICIT;
-    "avance", AVANCE;
     "total", TOTAL;
     "courant", COURANT;
     "retrocession", RETROCESSION;
-    "montant", MONTANT;
     "reste", RESTE;
     "non", NON;
     "opposable", OPPOSABLE;
@@ -59,7 +57,6 @@ let lident = [%sedlex.regexp? lowercase, Star (digit | lowercase | uppercase | '
 let uident = [%sedlex.regexp? uppercase, Star (digit | lowercase | uppercase | '_')]
 let date = [%sedlex.regexp? integer, '/', integer, '/', integer]
 let comment = [%sedlex.regexp? '#', Star (Compl '\n'), '\n']
-let label = [%sedlex.regexp? '\'', Plus (Compl ('\n' | '\r' | '\'')), '\'']
 
 let parse_money_value s : Z.t option =
   try (* Catch conversion errors. Should not happen from the lexer itself. *)
@@ -101,10 +98,6 @@ let parse_date s =
     Date.Date.make (int_of_string y) (int_of_string m) (int_of_string d)
   | _ -> raise (Invalid_argument "Lexer.parse_date")
 
-let strip_enclosing_chars s =
-  let s = String.trim s in
-  String.sub s 1 (String.length s - 2)
-
 let reading_code = ref false
 
 let rec code ~is_in_text lexbuf =
@@ -116,7 +109,6 @@ let rec code ~is_in_text lexbuf =
   | decimal -> FLOAT (R.of_string (Utf8.lexeme lexbuf))
   | integer -> INT (Z.of_string (Utf8.lexeme lexbuf))
   | money -> MONEY (parse_money_amount (Utf8.lexeme lexbuf))
-  | label -> LABEL (strip_enclosing_chars (Utf8.lexeme lexbuf))
   | '+' -> PLUS
   | '-' -> MINUS
   | '*' -> MULT

--- a/src/grammar/parser.messages
+++ b/src/grammar/parser.messages
@@ -1,582 +1,3 @@
-program: VERS
-##
-## Ends in an error in state: 26.
-##
-## program' -> . program [ # ]
-##
-## The known suffix of the stack is as follows:
-##
-##
-#
-
-Expected section or declaration.
-
-program: OPERATION LABEL VERS VERS
-##
-## Ends in an error in state: 74.
-##
-## destinataire -> VERS . holder [ VALEUR SUR RPAR RETROCESSION QUOTEPART QUAND POUR PAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## VERS
-##
-#
-program: EVENEMENT VERS
-##
-## Ends in an error in state: 156.
-##
-## event_decl -> EVENEMENT . LIDENT ATTEINT QUAND event_expr [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## EVENEMENT
-##
-#
-program: OPERATION LABEL VERS ASSIETTE VERS
-##
-## Ends in an error in state: 16.
-##
-## pool -> ASSIETTE . raw_pool [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## ASSIETTE
-##
-#
-program: OPERATION LABEL VERS LIDENT LBRA VERS
-##
-## Ends in an error in state: 12.
-##
-## labeled_actor_desc -> LIDENT LBRA . LIDENT RBRA [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MONTANT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## LIDENT LBRA
-##
-
-Expected lowercase identifier.
-
-
-
-program: OPERATION LABEL POUR VERS
-##
-## Ends in an error in state: 79.
-##
-## op_context -> POUR . context [ SUR QUAND POUR PAR COLON AVANT APRES ]
-##
-## The known suffix of the stack is as follows:
-## POUR
-##
-#
-program: OPERATION LABEL POUR UIDENT VERS
-##
-## Ends in an error in state: 80.
-##
-## context -> UIDENT . LPAR separated_nonempty_list(COMMA,UIDENT) RPAR [ VALEUR UIDENT TOUT SUR QUAND POUR PAR OPERATION MINUS EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON AVANT AVANCE ASSIETTE APRES ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## UIDENT
-##
-#
-program: OPERATION LABEL POUR TOUT VERS
-##
-## Ends in an error in state: 87.
-##
-## context -> TOUT . UIDENT [ VALEUR UIDENT TOUT SUR QUAND POUR PAR OPERATION MINUS EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON AVANT AVANCE ASSIETTE APRES ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## TOUT
-##
-
-Expected context cases of a given context type, either for all cases or by listing them.
-Examples:
- - pour Support Salles VOD
- - pour tout Support
-
-program: EVENEMENT LIDENT ATTEINT QUAND EVENEMENT LIDENT VERS
-##
-## Ends in an error in state: 160.
-##
-## event_decl -> EVENEMENT LIDENT ATTEINT QUAND event_expr . [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## event_expr_desc -> event_expr . ET event_expr [ VALEUR OU OPERATION EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## event_expr_desc -> event_expr . OU event_expr [ VALEUR OU OPERATION EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## EVENEMENT LIDENT ATTEINT QUAND event_expr
-##
-
-Unexpected word after event expression.
-
-program: OPERATION LABEL UIDENT
-##
-## Ends in an error in state: 73.
-##
-## operation -> OPERATION LABEL . option(destinataire) list(op_context) source expression(simple_exprs) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## OPERATION LABEL
-##
-
-Expected some context, or a destination, or a redistribution expression.
-
-program: OPERATION LABEL POUR TOUT UIDENT VERS
-##
-## Ends in an error in state: 90.
-##
-## list(op_context) -> op_context . list(op_context) [ SUR QUAND PAR COLON AVANT APRES ]
-##
-## The known suffix of the stack is as follows:
-## op_context
-##
-
-Unexpected word after context.
-
-program: EVENEMENT LIDENT VERS
-##
-## Ends in an error in state: 157.
-##
-## event_decl -> EVENEMENT LIDENT . ATTEINT QUAND event_expr [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## EVENEMENT LIDENT
-##
-#
-program: EVENEMENT LIDENT ATTEINT VERS
-##
-## Ends in an error in state: 158.
-##
-## event_decl -> EVENEMENT LIDENT ATTEINT . QUAND event_expr [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## EVENEMENT LIDENT ATTEINT
-##
-#
-program: EVENEMENT LIDENT ATTEINT QUAND VERS
-##
-## Ends in an error in state: 159.
-##
-## event_decl -> EVENEMENT LIDENT ATTEINT QUAND . event_expr [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## EVENEMENT LIDENT ATTEINT QUAND
-##
-
-Malformed event declaration. Well-formed examples:
-- evenement my_event atteint quand my_money = 100
-- evenement my_event atteint quand 2023/12/25
-
-program: ENTREE VERS
-##
-## Ends in an error in state: 161.
-##
-## input_decl -> ENTREE . LIDENT input_type loption(input_context_decl) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## input_decl -> ENTREE . ASSIETTE LIDENT loption(input_context_decl) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## ENTREE
-##
-#
-program: ENTREE LIDENT VERS
-##
-## Ends in an error in state: 162.
-##
-## input_decl -> ENTREE LIDENT . input_type loption(input_context_decl) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## ENTREE LIDENT
-##
-
-Malformed input declaration. An input is declared with an optional computable
-flag, a name, an optionnal context association, and a type.
-Well-formed examples:
-- entree my_input type entier
-- entree assiette my_input type argent contextualisee par My_context_type
-
-program: ENTREE LIDENT TYPE VERS
-##
-## Ends in an error in state: 163.
-##
-## input_type -> TYPE . base_type [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTUALISEE CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## TYPE
-##
-
-Expected a type identifier. It can be:
-- entier
-- rationnel
-- argent
-
-program: CONTEXTE VERS
-##
-## Ends in an error in state: 195.
-##
-## context_decl -> CONTEXTE . UIDENT COLON nonempty_list(context_case) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## CONTEXTE
-##
-#
-program: CONTEXTE UIDENT VERS
-##
-## Ends in an error in state: 196.
-##
-## context_decl -> CONTEXTE UIDENT . COLON nonempty_list(context_case) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## CONTEXTE UIDENT
-##
-#
-program: CONTEXTE UIDENT COLON VERS
-##
-## Ends in an error in state: 197.
-##
-## context_decl -> CONTEXTE UIDENT COLON . nonempty_list(context_case) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## CONTEXTE UIDENT COLON
-##
-#
-program: CONTEXTE UIDENT COLON MINUS VERS
-##
-## Ends in an error in state: 198.
-##
-## context_case -> MINUS . UIDENT [ VALEUR OPERATION MINUS EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## MINUS
-##
-#
-program: CONTEXTE UIDENT COLON MINUS UIDENT VERS
-##
-## Ends in an error in state: 201.
-##
-## nonempty_list(context_case) -> context_case . [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## nonempty_list(context_case) -> context_case . nonempty_list(context_case) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## context_case
-##
-
-Malformed context type declaration. Example:
-contexte My_context_type :
- - my_case_1
- - my_case_2
-
-program: CONSTANTE VERS
-##
-## Ends in an error in state: 203.
-##
-## constant_decl -> CONSTANTE . LIDENT COLON literal [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## CONSTANTE
-##
-#
-program: CONSTANTE LIDENT VERS
-##
-## Ends in an error in state: 204.
-##
-## constant_decl -> CONSTANTE LIDENT . COLON literal [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## CONSTANTE LIDENT
-##
-#
-program: CONSTANTE LIDENT COLON VERS
-##
-## Ends in an error in state: 205.
-##
-## constant_decl -> CONSTANTE LIDENT COLON . literal [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## CONSTANTE LIDENT COLON
-##
-
-Malformed constant declaration. Example:
-- constante my_const : 99.99
-
-
-program: OPERATION LABEL SUR VERS
-##
-## Ends in an error in state: 93.
-##
-## source -> SUR . pool [ RETROCESSION QUOTEPART QUAND BONUS AVANT APRES ]
-##
-## The known suffix of the stack is as follows:
-## SUR
-##
-
-Malformed source of repartition. Example:
-- sur assiette rbdApresCom
-
-program: OPERATION LABEL VERS LIDENT LBRA LIDENT VERS
-##
-## Ends in an error in state: 13.
-##
-## labeled_actor_desc -> LIDENT LBRA LIDENT . RBRA [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MONTANT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## LIDENT LBRA LIDENT
-##
-
-Expected closing bracket.
-
-program: OPERATION LABEL VERS ASSIETTE LIDENT VERS
-##
-## Ends in an error in state: 78.
-##
-## operation -> OPERATION LABEL option(destinataire) . list(op_context) source expression(simple_exprs) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## OPERATION LABEL option(destinataire)
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 17, spurious reduction of production raw_pool -> LIDENT
-## In state 19, spurious reduction of production pool -> ASSIETTE raw_pool
-## In state 75, spurious reduction of production holder -> pool
-## In state 76, spurious reduction of production destinataire -> VERS holder
-## In state 103, spurious reduction of production option(destinataire) -> destinataire
-##
-
-Unexpected word after destination.
-
-program: OPERATION LABEL SUR ASSIETTE LIDENT VERS
-##
-## Ends in an error in state: 97.
-##
-## operation -> OPERATION LABEL option(destinataire) list(op_context) source . expression(simple_exprs) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## OPERATION LABEL option(destinataire) list(op_context) source
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 17, spurious reduction of production raw_pool -> LIDENT
-## In state 19, spurious reduction of production pool -> ASSIETTE raw_pool
-## In state 94, spurious reduction of production source -> SUR pool
-##
-
-Unexpected word after source.
-
-program: OPERATION VERS
-##
-## Ends in an error in state: 72.
-##
-## operation -> OPERATION . LABEL option(destinataire) list(op_context) source expression(simple_exprs) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## OPERATION
-##
-
-Expected label for operation.
-
-program: DEFAUT VERS
-##
-## Ends in an error in state: 190.
-##
-## default_decl -> DEFAUT . SUR pool VERS holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## DEFAUT
-##
-#
-program: DEFAUT SUR ASSIETTE LIDENT UIDENT
-##
-## Ends in an error in state: 17.
-##
-## raw_pool -> LIDENT . [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## raw_pool -> LIDENT . context_refinement [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## LIDENT
-##
-#
-program: DEFAUT SUR ASSIETTE LIDENT VERS VERS
-##
-## Ends in an error in state: 193.
-##
-## default_decl -> DEFAUT SUR pool VERS . holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## DEFAUT SUR pool VERS
-##
-
-Malformed default declaration. Examples:
- - defaut sur assiette rbd vers assiette rnpp
- - defaut sur assiette rnpp vers prod[residuel]
-
-program: AVANCE VERS
-##
-## Ends in an error in state: 207.
-##
-## advance -> AVANCE . LABEL SUR holder PAR actor MONTANT formula [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## AVANCE
-##
-#
-program: AVANCE LABEL VERS
-##
-## Ends in an error in state: 208.
-##
-## advance -> AVANCE LABEL . SUR holder PAR actor MONTANT formula [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## AVANCE LABEL
-##
-#
-program: AVANCE LABEL SUR ASSIETTE LIDENT VERS
-##
-## Ends in an error in state: 210.
-##
-## advance -> AVANCE LABEL SUR holder . PAR actor MONTANT formula [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## AVANCE LABEL SUR holder
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 17, spurious reduction of production raw_pool -> LIDENT
-## In state 19, spurious reduction of production pool -> ASSIETTE raw_pool
-## In state 75, spurious reduction of production holder -> pool
-##
-#
-program: AVANCE LABEL SUR ASSIETTE LIDENT PAR VERS
-##
-## Ends in an error in state: 211.
-##
-## advance -> AVANCE LABEL SUR holder PAR . actor MONTANT formula [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## AVANCE LABEL SUR holder PAR
-##
-
-Malformed advance declaration. Example:
-- avance 'my_advance' sur my_source par my_provider montant 5000$ vers my_output
-
-program: DEFICIT VERS
-##
-## Ends in an error in state: 185.
-##
-## deficit_decl -> DEFICIT . SUR pool PAR holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## DEFICIT
-##
-#
-program: DEFICIT SUR ASSIETTE LIDENT VERS
-##
-## Ends in an error in state: 187.
-##
-## deficit_decl -> DEFICIT SUR pool . PAR holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## DEFICIT SUR pool
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 17, spurious reduction of production raw_pool -> LIDENT
-## In state 19, spurious reduction of production pool -> ASSIETTE raw_pool
-##
-#
-program: DEFICIT SUR ASSIETTE LIDENT PAR VERS
-##
-## Ends in an error in state: 188.
-##
-## deficit_decl -> DEFICIT SUR pool PAR . holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## DEFICIT SUR pool PAR
-##
-
-Malformed deficit declaration. Syntax:
-- deficit sur my_assiette PAR my_acteur
-
-program: DEFAUT SUR ASSIETTE LIDENT LPAR VERS
-##
-## Ends in an error in state: 2.
-##
-## context_refinement -> LPAR . separated_nonempty_list(COMMA,context_refine_item) RPAR [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-##
-## The known suffix of the stack is as follows:
-## LPAR
-##
-#
-program: DEFAUT SUR ASSIETTE LIDENT LPAR TOUT VERS
-##
-## Ends in an error in state: 4.
-##
-## context_refinement_item_desc -> TOUT . UIDENT [ RPAR COMMA ]
-##
-## The known suffix of the stack is as follows:
-## TOUT
-##
-#
-program: DEFAUT SUR ASSIETTE LIDENT LPAR UIDENT VERS
-##
-## Ends in an error in state: 9.
-##
-## separated_nonempty_list(COMMA,context_refine_item) -> context_refine_item . [ RPAR ]
-## separated_nonempty_list(COMMA,context_refine_item) -> context_refine_item . COMMA separated_nonempty_list(COMMA,context_refine_item) [ RPAR ]
-##
-## The known suffix of the stack is as follows:
-## context_refine_item
-##
-#
-program: DEFAUT SUR ASSIETTE LIDENT LPAR UIDENT COMMA VERS
-##
-## Ends in an error in state: 10.
-##
-## separated_nonempty_list(COMMA,context_refine_item) -> context_refine_item COMMA . separated_nonempty_list(COMMA,context_refine_item) [ RPAR ]
-##
-## The known suffix of the stack is as follows:
-## context_refine_item COMMA
-##
-
-Malformed context refinement. Syntax:
-- rbd(Salles,France,tout Secteur)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 named_start: VERS
 ##
 ## Ends in an error in state: 0.
@@ -589,7 +10,105 @@ named_start: VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-named_start: LIDENT VERS
+named_start: LIDENT LPAR VERS
+##
+## Ends in an error in state: 2.
+##
+## context_refinement -> LPAR . separated_nonempty_list(COMMA,context_refine_item) RPAR [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## LPAR
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+named_start: LIDENT LPAR TOUT VERS
+##
+## Ends in an error in state: 4.
+##
+## context_refinement_item_desc -> TOUT . UIDENT [ RPAR COMMA ]
+##
+## The known suffix of the stack is as follows:
+## TOUT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+named_start: LIDENT LPAR UIDENT VERS
+##
+## Ends in an error in state: 9.
+##
+## separated_nonempty_list(COMMA,context_refine_item) -> context_refine_item . [ RPAR ]
+## separated_nonempty_list(COMMA,context_refine_item) -> context_refine_item . COMMA separated_nonempty_list(COMMA,context_refine_item) [ RPAR ]
+##
+## The known suffix of the stack is as follows:
+## context_refine_item
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+named_start: LIDENT LPAR UIDENT COMMA VERS
+##
+## Ends in an error in state: 10.
+##
+## separated_nonempty_list(COMMA,context_refine_item) -> context_refine_item COMMA . separated_nonempty_list(COMMA,context_refine_item) [ RPAR ]
+##
+## The known suffix of the stack is as follows:
+## context_refine_item COMMA
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+named_start: LIDENT LBRA VERS
+##
+## Ends in an error in state: 12.
+##
+## labeled_actor_desc -> LIDENT LBRA . LIDENT RBRA [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## LIDENT LBRA
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+named_start: LIDENT LBRA LIDENT VERS
+##
+## Ends in an error in state: 13.
+##
+## labeled_actor_desc -> LIDENT LBRA LIDENT . RBRA [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## LIDENT LBRA LIDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+named_start: ASSIETTE VERS
+##
+## Ends in an error in state: 16.
+##
+## pool -> ASSIETTE . raw_pool [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## ASSIETTE
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+raw_pool_start: LIDENT UIDENT
+##
+## Ends in an error in state: 17.
+##
+## raw_pool -> LIDENT . [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## raw_pool -> LIDENT . context_refinement [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## LIDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+named_start: LIDENT UIDENT
 ##
 ## Ends in an error in state: 22.
 ##
@@ -607,11 +126,23 @@ named_start: LIDENT VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+program: VERS
+##
+## Ends in an error in state: 26.
+##
+## program' -> . program [ # ]
+##
+## The known suffix of the stack is as follows:
+##
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 program: VALEUR VERS
 ##
 ## Ends in an error in state: 27.
 ##
-## value_decl -> VALEUR . boption(OBSERVABLE) LIDENT value_def [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## value_decl -> VALEUR . boption(OBSERVABLE) LIDENT value_def [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## VALEUR
@@ -623,7 +154,7 @@ program: VALEUR OBSERVABLE VERS
 ##
 ## Ends in an error in state: 29.
 ##
-## value_decl -> VALEUR boption(OBSERVABLE) . LIDENT value_def [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## value_decl -> VALEUR boption(OBSERVABLE) . LIDENT value_def [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## VALEUR boption(OBSERVABLE)
@@ -635,7 +166,7 @@ program: VALEUR LIDENT VERS
 ##
 ## Ends in an error in state: 30.
 ##
-## value_decl -> VALEUR boption(OBSERVABLE) LIDENT . value_def [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## value_decl -> VALEUR boption(OBSERVABLE) LIDENT . value_def [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## VALEUR boption(OBSERVABLE) LIDENT
@@ -647,7 +178,7 @@ program: VALEUR LIDENT COLON VERS
 ##
 ## Ends in an error in state: 31.
 ##
-## value_def -> COLON . formula [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## value_def -> COLON . formula [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## COLON
@@ -659,7 +190,7 @@ program: VALEUR LIDENT COLON LPAR VERS
 ##
 ## Ends in an error in state: 33.
 ##
-## formula -> LPAR . formula RPAR [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## formula -> LPAR . formula RPAR [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAR
@@ -667,11 +198,11 @@ program: VALEUR LIDENT COLON LPAR VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: CONSTANTE LIDENT COLON INT ANS UIDENT
+program: VALEUR LIDENT COLON INT ANS UIDENT
 ##
 ## Ends in an error in state: 36.
 ##
-## duration_year -> INT ANS . option(duration_month) [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## duration_year -> INT ANS . option(duration_month) [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## INT ANS
@@ -679,11 +210,11 @@ program: CONSTANTE LIDENT COLON INT ANS UIDENT
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: CONSTANTE LIDENT COLON INT ANS INT VERS
+program: VALEUR LIDENT COLON INT ANS INT VERS
 ##
 ## Ends in an error in state: 37.
 ##
-## duration_month -> INT . MOIS [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## duration_month -> INT . MOIS [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## INT
@@ -691,11 +222,11 @@ program: CONSTANTE LIDENT COLON INT ANS INT VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: VALEUR LIDENT COLON LPAR DATE VERS
+program: VALEUR LIDENT COLON LPAR DATE POUR
 ##
 ## Ends in an error in state: 45.
 ##
-## formula -> LPAR formula . RPAR [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## formula -> LPAR formula . RPAR [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ## formula_desc -> formula . PLUS formula [ TOTAL RPAR PLUS OPPOSABLE MULT MINUS DIV COURANT ]
 ## formula_desc -> formula . MINUS formula [ TOTAL RPAR PLUS OPPOSABLE MULT MINUS DIV COURANT ]
 ## formula_desc -> formula . MULT formula [ TOTAL RPAR PLUS OPPOSABLE MULT MINUS DIV COURANT ]
@@ -714,7 +245,7 @@ program: VALEUR LIDENT COLON DATE PLUS VERS
 ##
 ## Ends in an error in state: 48.
 ##
-## formula_desc -> formula PLUS . formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula PLUS . formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## formula PLUS
@@ -722,18 +253,18 @@ program: VALEUR LIDENT COLON DATE PLUS VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: VALEUR LIDENT COLON DATE PLUS DATE MOIS
+program: VALEUR LIDENT COLON DATE PLUS DATE POUR
 ##
 ## Ends in an error in state: 49.
 ##
-## formula_desc -> formula . PLUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula PLUS formula . [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MINUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MULT formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . DIV formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . COURANT [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . TOTAL [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . opposable [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . PLUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula PLUS formula . [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MINUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MULT formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . DIV formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . COURANT [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . TOTAL [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . opposable [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## formula PLUS formula
@@ -745,7 +276,7 @@ program: VALEUR LIDENT COLON DATE OPPOSABLE VERS
 ##
 ## Ends in an error in state: 50.
 ##
-## opposable -> OPPOSABLE . formula ENVERS actor PAR actor [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## opposable -> OPPOSABLE . formula ENVERS actor PAR actor [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## OPPOSABLE
@@ -753,7 +284,7 @@ program: VALEUR LIDENT COLON DATE OPPOSABLE VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: VALEUR LIDENT COLON DATE OPPOSABLE DATE VERS
+program: VALEUR LIDENT COLON DATE OPPOSABLE DATE POUR
 ##
 ## Ends in an error in state: 51.
 ##
@@ -764,7 +295,7 @@ program: VALEUR LIDENT COLON DATE OPPOSABLE DATE VERS
 ## formula_desc -> formula . COURANT [ TOTAL PLUS OPPOSABLE MULT MINUS ENVERS DIV COURANT ]
 ## formula_desc -> formula . TOTAL [ TOTAL PLUS OPPOSABLE MULT MINUS ENVERS DIV COURANT ]
 ## formula_desc -> formula . opposable [ TOTAL PLUS OPPOSABLE MULT MINUS ENVERS DIV COURANT ]
-## opposable -> OPPOSABLE formula . ENVERS actor PAR actor [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## opposable -> OPPOSABLE formula . ENVERS actor PAR actor [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## OPPOSABLE formula
@@ -776,7 +307,7 @@ program: VALEUR LIDENT COLON DATE MULT VERS
 ##
 ## Ends in an error in state: 52.
 ##
-## formula_desc -> formula MULT . formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula MULT . formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## formula MULT
@@ -784,18 +315,18 @@ program: VALEUR LIDENT COLON DATE MULT VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: VALEUR LIDENT COLON DATE MULT DATE MOIS
+program: VALEUR LIDENT COLON DATE MULT DATE POUR
 ##
 ## Ends in an error in state: 53.
 ##
-## formula_desc -> formula . PLUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MINUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MULT formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula MULT formula . [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . DIV formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . COURANT [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . TOTAL [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . opposable [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . PLUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MINUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MULT formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula MULT formula . [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . DIV formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . COURANT [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . TOTAL [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . opposable [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## formula MULT formula
@@ -807,7 +338,7 @@ program: VALEUR LIDENT COLON DATE MINUS VERS
 ##
 ## Ends in an error in state: 59.
 ##
-## formula_desc -> formula MINUS . formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula MINUS . formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## formula MINUS
@@ -815,18 +346,18 @@ program: VALEUR LIDENT COLON DATE MINUS VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: VALEUR LIDENT COLON DATE MINUS DATE MOIS
+program: VALEUR LIDENT COLON DATE MINUS DATE POUR
 ##
 ## Ends in an error in state: 60.
 ##
-## formula_desc -> formula . PLUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MINUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula MINUS formula . [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MULT formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . DIV formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . COURANT [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . TOTAL [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . opposable [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . PLUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MINUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula MINUS formula . [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MULT formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . DIV formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . COURANT [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . TOTAL [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . opposable [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## formula MINUS formula
@@ -838,7 +369,7 @@ program: VALEUR LIDENT COLON DATE DIV VERS
 ##
 ## Ends in an error in state: 61.
 ##
-## formula_desc -> formula DIV . formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula DIV . formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## formula DIV
@@ -846,18 +377,18 @@ program: VALEUR LIDENT COLON DATE DIV VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: VALEUR LIDENT COLON DATE DIV DATE MOIS
+program: VALEUR LIDENT COLON DATE DIV DATE POUR
 ##
 ## Ends in an error in state: 62.
 ##
-## formula_desc -> formula . PLUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MINUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MULT formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . DIV formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula DIV formula . [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . COURANT [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . TOTAL [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . opposable [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . PLUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MINUS formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MULT formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . DIV formula [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula DIV formula . [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . COURANT [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . TOTAL [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . opposable [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## formula DIV formula
@@ -869,7 +400,7 @@ program: VALEUR LIDENT COLON DATE OPPOSABLE DATE ENVERS VERS
 ##
 ## Ends in an error in state: 63.
 ##
-## opposable -> OPPOSABLE formula ENVERS . actor PAR actor [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## opposable -> OPPOSABLE formula ENVERS . actor PAR actor [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## OPPOSABLE formula ENVERS
@@ -877,12 +408,12 @@ program: VALEUR LIDENT COLON DATE OPPOSABLE DATE ENVERS VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: AVANCE LABEL SUR LIDENT UIDENT
+program: OPERATION PAR LIDENT UIDENT
 ##
 ## Ends in an error in state: 64.
 ##
-## actor_desc -> LIDENT . [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MONTANT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## labeled_actor_desc -> LIDENT . LBRA LIDENT RBRA [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MONTANT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## actor_desc -> LIDENT . [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
+## labeled_actor_desc -> LIDENT . LBRA LIDENT RBRA [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND POUR PLUS PAR OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## LIDENT
@@ -894,7 +425,7 @@ program: VALEUR LIDENT COLON DATE OPPOSABLE DATE ENVERS LIDENT VERS
 ##
 ## Ends in an error in state: 67.
 ##
-## opposable -> OPPOSABLE formula ENVERS actor . PAR actor [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## opposable -> OPPOSABLE formula ENVERS actor . PAR actor [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## OPPOSABLE formula ENVERS actor
@@ -913,7 +444,7 @@ program: VALEUR LIDENT COLON DATE OPPOSABLE DATE ENVERS LIDENT PAR VERS
 ##
 ## Ends in an error in state: 68.
 ##
-## opposable -> OPPOSABLE formula ENVERS actor PAR . actor [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## opposable -> OPPOSABLE formula ENVERS actor PAR . actor [ VERS VALEUR TOTAL SUR RPAR RETROCESSION QUOTEPART QUAND PLUS OU OPPOSABLE OPERATION NON MULT MINUS LPAR EVENEMENT ET EQ EOF ENVERS ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## OPPOSABLE formula ENVERS actor PAR
@@ -921,18 +452,18 @@ program: VALEUR LIDENT COLON DATE OPPOSABLE DATE ENVERS LIDENT PAR VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: VALEUR LIDENT COLON DATE VERS
+program: VALEUR LIDENT COLON DATE POUR
 ##
 ## Ends in an error in state: 70.
 ##
-## formula_desc -> formula . PLUS formula [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MINUS formula [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MULT formula [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . DIV formula [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . COURANT [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . TOTAL [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . opposable [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## value_def -> COLON formula . [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . PLUS formula [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MINUS formula [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MULT formula [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . DIV formula [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . COURANT [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . TOTAL [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . opposable [ VALEUR TOTAL RPAR QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
+## value_def -> COLON formula . [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## COLON formula
@@ -940,11 +471,81 @@ program: VALEUR LIDENT COLON DATE VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL POUR UIDENT LPAR VERS
+program: OPERATION VALEUR
 ##
-## Ends in an error in state: 81.
+## Ends in an error in state: 72.
 ##
-## context -> UIDENT LPAR . separated_nonempty_list(COMMA,UIDENT) RPAR [ VALEUR UIDENT TOUT SUR QUAND POUR PAR OPERATION MINUS EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## operation -> OPERATION . option(destinataire) list(op_context) source expression(simple_exprs) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## OPERATION
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: OPERATION VERS VERS
+##
+## Ends in an error in state: 73.
+##
+## destinataire -> VERS . holder [ VALEUR SUR RPAR RETROCESSION QUOTEPART QUAND POUR PAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## VERS
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: OPERATION VERS LIDENT LPAR
+##
+## Ends in an error in state: 77.
+##
+## operation -> OPERATION option(destinataire) . list(op_context) source expression(simple_exprs) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## OPERATION option(destinataire)
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 64, spurious reduction of production actor_desc -> LIDENT
+## In state 66, spurious reduction of production actor -> actor_desc
+## In state 76, spurious reduction of production holder -> actor
+## In state 75, spurious reduction of production destinataire -> VERS holder
+## In state 102, spurious reduction of production option(destinataire) -> destinataire
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: OPERATION POUR VERS
+##
+## Ends in an error in state: 78.
+##
+## op_context -> POUR . context [ SUR QUAND POUR PAR COLON AVANT APRES ]
+##
+## The known suffix of the stack is as follows:
+## POUR
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: OPERATION POUR UIDENT VERS
+##
+## Ends in an error in state: 79.
+##
+## context -> UIDENT . LPAR separated_nonempty_list(COMMA,UIDENT) RPAR [ VALEUR UIDENT TOUT SUR QUAND POUR PAR OPERATION MINUS EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON AVANT ASSIETTE APRES ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## UIDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: OPERATION POUR UIDENT LPAR VERS
+##
+## Ends in an error in state: 80.
+##
+## context -> UIDENT LPAR . separated_nonempty_list(COMMA,UIDENT) RPAR [ VALEUR UIDENT TOUT SUR QUAND POUR PAR OPERATION MINUS EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## UIDENT LPAR
@@ -952,9 +553,9 @@ program: OPERATION LABEL POUR UIDENT LPAR VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL POUR UIDENT LPAR UIDENT VERS
+program: OPERATION POUR UIDENT LPAR UIDENT VERS
 ##
-## Ends in an error in state: 82.
+## Ends in an error in state: 81.
 ##
 ## separated_nonempty_list(COMMA,UIDENT) -> UIDENT . [ RPAR ]
 ## separated_nonempty_list(COMMA,UIDENT) -> UIDENT . COMMA separated_nonempty_list(COMMA,UIDENT) [ RPAR ]
@@ -965,9 +566,9 @@ program: OPERATION LABEL POUR UIDENT LPAR UIDENT VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL POUR UIDENT LPAR UIDENT COMMA VERS
+program: OPERATION POUR UIDENT LPAR UIDENT COMMA VERS
 ##
-## Ends in an error in state: 83.
+## Ends in an error in state: 82.
 ##
 ## separated_nonempty_list(COMMA,UIDENT) -> UIDENT COMMA . separated_nonempty_list(COMMA,UIDENT) [ RPAR ]
 ##
@@ -977,28 +578,64 @@ program: OPERATION LABEL POUR UIDENT LPAR UIDENT COMMA VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL POUR TOUT UIDENT QUAND
+program: OPERATION POUR TOUT VERS
 ##
-## Ends in an error in state: 92.
+## Ends in an error in state: 86.
 ##
-## operation -> OPERATION LABEL option(destinataire) list(op_context) . source expression(simple_exprs) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## context -> TOUT . UIDENT [ VALEUR UIDENT TOUT SUR QUAND POUR PAR OPERATION MINUS EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
-## OPERATION LABEL option(destinataire) list(op_context)
+## TOUT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: OPERATION POUR TOUT UIDENT VERS
+##
+## Ends in an error in state: 89.
+##
+## list(op_context) -> op_context . list(op_context) [ SUR QUAND PAR COLON AVANT APRES ]
+##
+## The known suffix of the stack is as follows:
+## op_context
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: OPERATION POUR TOUT UIDENT QUAND
+##
+## Ends in an error in state: 91.
+##
+## operation -> OPERATION option(destinataire) list(op_context) . source expression(simple_exprs) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## OPERATION option(destinataire) list(op_context)
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 90, spurious reduction of production list(op_context) ->
-## In state 91, spurious reduction of production list(op_context) -> op_context list(op_context)
+## In state 89, spurious reduction of production list(op_context) ->
+## In state 90, spurious reduction of production list(op_context) -> op_context list(op_context)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR VERS
+program: OPERATION SUR VERS
 ##
-## Ends in an error in state: 95.
+## Ends in an error in state: 92.
+##
+## source -> SUR . pool [ RETROCESSION QUOTEPART QUAND BONUS AVANT APRES ]
+##
+## The known suffix of the stack is as follows:
+## SUR
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: OPERATION PAR VERS
+##
+## Ends in an error in state: 94.
 ##
 ## source -> PAR . actor [ RETROCESSION QUOTEPART QUAND BONUS AVANT APRES ]
 ##
@@ -1008,11 +645,31 @@ program: OPERATION LABEL PAR VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT RETROCESSION VERS
+program: OPERATION PAR LIDENT LPAR
 ##
-## Ends in an error in state: 98.
+## Ends in an error in state: 96.
 ##
-## simple_expr -> RETROCESSION . formula SUR holder option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## operation -> OPERATION option(destinataire) list(op_context) source . expression(simple_exprs) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## OPERATION option(destinataire) list(op_context) source
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 64, spurious reduction of production actor_desc -> LIDENT
+## In state 66, spurious reduction of production actor -> actor_desc
+## In state 95, spurious reduction of production source -> PAR actor
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: OPERATION PAR LIDENT RETROCESSION VERS
+##
+## Ends in an error in state: 97.
+##
+## simple_expr -> RETROCESSION . formula SUR holder option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## RETROCESSION
@@ -1020,9 +677,9 @@ program: OPERATION LABEL PAR LIDENT RETROCESSION VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT RETROCESSION DATE VERS
+program: OPERATION PAR LIDENT RETROCESSION DATE POUR
 ##
-## Ends in an error in state: 99.
+## Ends in an error in state: 98.
 ##
 ## formula_desc -> formula . PLUS formula [ TOTAL SUR PLUS OPPOSABLE MULT MINUS DIV COURANT ]
 ## formula_desc -> formula . MINUS formula [ TOTAL SUR PLUS OPPOSABLE MULT MINUS DIV COURANT ]
@@ -1031,7 +688,7 @@ program: OPERATION LABEL PAR LIDENT RETROCESSION DATE VERS
 ## formula_desc -> formula . COURANT [ TOTAL SUR PLUS OPPOSABLE MULT MINUS DIV COURANT ]
 ## formula_desc -> formula . TOTAL [ TOTAL SUR PLUS OPPOSABLE MULT MINUS DIV COURANT ]
 ## formula_desc -> formula . opposable [ TOTAL SUR PLUS OPPOSABLE MULT MINUS DIV COURANT ]
-## simple_expr -> RETROCESSION formula . SUR holder option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## simple_expr -> RETROCESSION formula . SUR holder option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## RETROCESSION formula
@@ -1039,11 +696,11 @@ program: OPERATION LABEL PAR LIDENT RETROCESSION DATE VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT RETROCESSION DATE SUR VERS
+program: OPERATION PAR LIDENT RETROCESSION DATE SUR VERS
 ##
-## Ends in an error in state: 100.
+## Ends in an error in state: 99.
 ##
-## simple_expr -> RETROCESSION formula SUR . holder option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## simple_expr -> RETROCESSION formula SUR . holder option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## RETROCESSION formula SUR
@@ -1051,11 +708,11 @@ program: OPERATION LABEL PAR LIDENT RETROCESSION DATE SUR VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT RETROCESSION DATE SUR LIDENT TOTAL
+program: OPERATION PAR LIDENT RETROCESSION DATE SUR LIDENT LPAR
 ##
-## Ends in an error in state: 101.
+## Ends in an error in state: 100.
 ##
-## simple_expr -> RETROCESSION formula SUR holder . option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## simple_expr -> RETROCESSION formula SUR holder . option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## RETROCESSION formula SUR holder
@@ -1066,17 +723,17 @@ program: OPERATION LABEL PAR LIDENT RETROCESSION DATE SUR LIDENT TOTAL
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 64, spurious reduction of production actor_desc -> LIDENT
 ## In state 66, spurious reduction of production actor -> actor_desc
-## In state 77, spurious reduction of production holder -> actor
+## In state 76, spurious reduction of production holder -> actor
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT QUOTEPART VERS
+program: OPERATION PAR LIDENT QUOTEPART VERS
 ##
-## Ends in an error in state: 104.
+## Ends in an error in state: 103.
 ##
-## simple_expr -> QUOTEPART . formula boption(pair(NON,OPPOSABLE)) option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## simple_expr -> QUOTEPART . RESTE option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## simple_expr -> QUOTEPART . formula boption(pair(NON,OPPOSABLE)) option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## simple_expr -> QUOTEPART . RESTE option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## QUOTEPART
@@ -1084,11 +741,11 @@ program: OPERATION LABEL PAR LIDENT QUOTEPART VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT QUOTEPART RESTE UIDENT
+program: OPERATION PAR LIDENT QUOTEPART RESTE UIDENT
 ##
-## Ends in an error in state: 105.
+## Ends in an error in state: 104.
 ##
-## simple_expr -> QUOTEPART RESTE . option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## simple_expr -> QUOTEPART RESTE . option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## QUOTEPART RESTE
@@ -1096,18 +753,18 @@ program: OPERATION LABEL PAR LIDENT QUOTEPART RESTE UIDENT
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT QUOTEPART DATE SUR
+program: OPERATION PAR LIDENT QUOTEPART DATE POUR
 ##
-## Ends in an error in state: 107.
+## Ends in an error in state: 106.
 ##
-## formula_desc -> formula . PLUS formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MINUS formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MULT formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . DIV formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . COURANT [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . TOTAL [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . opposable [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## simple_expr -> QUOTEPART formula . boption(pair(NON,OPPOSABLE)) option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . PLUS formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MINUS formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MULT formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . DIV formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . COURANT [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . TOTAL [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . opposable [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION NON MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## simple_expr -> QUOTEPART formula . boption(pair(NON,OPPOSABLE)) option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## QUOTEPART formula
@@ -1115,11 +772,11 @@ program: OPERATION LABEL PAR LIDENT QUOTEPART DATE SUR
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT QUOTEPART DATE NON VERS
+program: OPERATION PAR LIDENT QUOTEPART DATE NON VERS
 ##
-## Ends in an error in state: 108.
+## Ends in an error in state: 107.
 ##
-## boption(pair(NON,OPPOSABLE)) -> NON . OPPOSABLE [ VERS VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## boption(pair(NON,OPPOSABLE)) -> NON . OPPOSABLE [ VERS VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## NON
@@ -1127,11 +784,11 @@ program: OPERATION LABEL PAR LIDENT QUOTEPART DATE NON VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT QUOTEPART DATE NON OPPOSABLE UIDENT
+program: OPERATION PAR LIDENT QUOTEPART DATE NON OPPOSABLE UIDENT
 ##
-## Ends in an error in state: 110.
+## Ends in an error in state: 109.
 ##
-## simple_expr -> QUOTEPART formula boption(pair(NON,OPPOSABLE)) . option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## simple_expr -> QUOTEPART formula boption(pair(NON,OPPOSABLE)) . option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## QUOTEPART formula boption(pair(NON,OPPOSABLE))
@@ -1139,11 +796,11 @@ program: OPERATION LABEL PAR LIDENT QUOTEPART DATE NON OPPOSABLE UIDENT
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT QUAND VERS
+program: OPERATION PAR LIDENT QUAND VERS
 ##
-## Ends in an error in state: 112.
+## Ends in an error in state: 111.
 ##
-## when_expr(simple_exprs) -> QUAND . event_expr sub_expression(simple_exprs) [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## when_expr(simple_exprs) -> QUAND . event_expr sub_expression(simple_exprs) [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## QUAND
@@ -1151,11 +808,11 @@ program: OPERATION LABEL PAR LIDENT QUAND VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: EVENEMENT LIDENT ATTEINT QUAND EVENEMENT VERS
+program: OPERATION PAR LIDENT QUAND EVENEMENT VERS
 ##
-## Ends in an error in state: 113.
+## Ends in an error in state: 112.
 ##
-## event_expr_desc -> EVENEMENT . LIDENT [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
+## event_expr_desc -> EVENEMENT . LIDENT [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## EVENEMENT
@@ -1163,11 +820,11 @@ program: EVENEMENT LIDENT ATTEINT QUAND EVENEMENT VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: EVENEMENT LIDENT ATTEINT QUAND DATE VERS
+program: OPERATION PAR LIDENT QUAND DATE POUR
 ##
-## Ends in an error in state: 115.
+## Ends in an error in state: 114.
 ##
-## event_expr_desc -> formula . EQ formula [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
+## event_expr_desc -> formula . EQ formula [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
 ## formula_desc -> formula . PLUS formula [ TOTAL PLUS OPPOSABLE MULT MINUS EQ DIV COURANT ]
 ## formula_desc -> formula . MINUS formula [ TOTAL PLUS OPPOSABLE MULT MINUS EQ DIV COURANT ]
 ## formula_desc -> formula . MULT formula [ TOTAL PLUS OPPOSABLE MULT MINUS EQ DIV COURANT ]
@@ -1182,11 +839,11 @@ program: EVENEMENT LIDENT ATTEINT QUAND DATE VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: EVENEMENT LIDENT ATTEINT QUAND DATE EQ VERS
+program: OPERATION PAR LIDENT QUAND DATE EQ VERS
 ##
-## Ends in an error in state: 116.
+## Ends in an error in state: 115.
 ##
-## event_expr_desc -> formula EQ . formula [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
+## event_expr_desc -> formula EQ . formula [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## formula EQ
@@ -1194,18 +851,18 @@ program: EVENEMENT LIDENT ATTEINT QUAND DATE EQ VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: EVENEMENT LIDENT ATTEINT QUAND DATE EQ DATE VERS
+program: OPERATION PAR LIDENT QUAND DATE EQ DATE POUR
 ##
-## Ends in an error in state: 117.
+## Ends in an error in state: 116.
 ##
-## event_expr_desc -> formula EQ formula . [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . PLUS formula [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . MINUS formula [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . MULT formula [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . DIV formula [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . COURANT [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . TOTAL [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . opposable [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
+## event_expr_desc -> formula EQ formula . [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
+## formula_desc -> formula . PLUS formula [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
+## formula_desc -> formula . MINUS formula [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
+## formula_desc -> formula . MULT formula [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
+## formula_desc -> formula . DIV formula [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
+## formula_desc -> formula . COURANT [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
+## formula_desc -> formula . TOTAL [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
+## formula_desc -> formula . opposable [ VALEUR TOTAL RETROCESSION QUOTEPART PLUS OU OPPOSABLE OPERATION MULT MINUS LPAR EVENEMENT ET EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## formula EQ formula
@@ -1213,13 +870,13 @@ program: EVENEMENT LIDENT ATTEINT QUAND DATE EQ DATE VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT QUAND EVENEMENT LIDENT VALEUR
+program: OPERATION PAR LIDENT QUAND EVENEMENT LIDENT VERS
 ##
-## Ends in an error in state: 119.
+## Ends in an error in state: 118.
 ##
 ## event_expr_desc -> event_expr . ET event_expr [ RETROCESSION QUOTEPART OU LPAR ET BONUS ]
 ## event_expr_desc -> event_expr . OU event_expr [ RETROCESSION QUOTEPART OU LPAR ET BONUS ]
-## when_expr(simple_exprs) -> QUAND event_expr . sub_expression(simple_exprs) [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## when_expr(simple_exprs) -> QUAND event_expr . sub_expression(simple_exprs) [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## QUAND event_expr
@@ -1229,9 +886,9 @@ program: OPERATION LABEL PAR LIDENT QUAND EVENEMENT LIDENT VALEUR
 
 program: EVENEMENT LIDENT ATTEINT QUAND EVENEMENT LIDENT OU VERS
 ##
-## Ends in an error in state: 120.
+## Ends in an error in state: 119.
 ##
-## event_expr_desc -> event_expr OU . event_expr [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
+## event_expr_desc -> event_expr OU . event_expr [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## event_expr OU
@@ -1241,11 +898,11 @@ program: EVENEMENT LIDENT ATTEINT QUAND EVENEMENT LIDENT OU VERS
 
 program: EVENEMENT LIDENT ATTEINT QUAND EVENEMENT LIDENT OU EVENEMENT LIDENT VERS
 ##
-## Ends in an error in state: 121.
+## Ends in an error in state: 120.
 ##
-## event_expr_desc -> event_expr . ET event_expr [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
-## event_expr_desc -> event_expr . OU event_expr [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
-## event_expr_desc -> event_expr OU event_expr . [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
+## event_expr_desc -> event_expr . ET event_expr [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
+## event_expr_desc -> event_expr . OU event_expr [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
+## event_expr_desc -> event_expr OU event_expr . [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## event_expr OU event_expr
@@ -1255,9 +912,9 @@ program: EVENEMENT LIDENT ATTEINT QUAND EVENEMENT LIDENT OU EVENEMENT LIDENT VER
 
 program: EVENEMENT LIDENT ATTEINT QUAND EVENEMENT LIDENT ET VERS
 ##
-## Ends in an error in state: 122.
+## Ends in an error in state: 121.
 ##
-## event_expr_desc -> event_expr ET . event_expr [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS AVANCE ASSIETTE ACTEUR ]
+## event_expr_desc -> event_expr ET . event_expr [ VALEUR RETROCESSION QUOTEPART OU OPERATION LPAR EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE COLON BONUS ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## event_expr ET
@@ -1265,11 +922,11 @@ program: EVENEMENT LIDENT ATTEINT QUAND EVENEMENT LIDENT ET VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT APRES EVENEMENT LIDENT LPAR VERS
+program: OPERATION PAR LIDENT APRES EVENEMENT LIDENT LPAR VERS
 ##
-## Ends in an error in state: 124.
+## Ends in an error in state: 123.
 ##
-## sub_expression(simple_exprs) -> LPAR . expression(simple_exprs) RPAR [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## sub_expression(simple_exprs) -> LPAR . expression(simple_exprs) RPAR [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAR
@@ -1277,11 +934,11 @@ program: OPERATION LABEL PAR LIDENT APRES EVENEMENT LIDENT LPAR VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT BONUS VERS
+program: OPERATION PAR LIDENT BONUS VERS
 ##
-## Ends in an error in state: 125.
+## Ends in an error in state: 124.
 ##
-## simple_expr -> BONUS . formula option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## simple_expr -> BONUS . formula option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## BONUS
@@ -1289,18 +946,18 @@ program: OPERATION LABEL PAR LIDENT BONUS VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT BONUS DATE SUR
+program: OPERATION PAR LIDENT BONUS DATE POUR
 ##
-## Ends in an error in state: 126.
+## Ends in an error in state: 125.
 ##
-## formula_desc -> formula . PLUS formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MINUS formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . MULT formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . DIV formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . COURANT [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . TOTAL [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## formula_desc -> formula . opposable [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## simple_expr -> BONUS formula . option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . PLUS formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MINUS formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . MULT formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . DIV formula [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . COURANT [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . TOTAL [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## formula_desc -> formula . opposable [ VERS VALEUR TOTAL RPAR RETROCESSION QUOTEPART QUAND PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
+## simple_expr -> BONUS formula . option(destinataire) [ VALEUR RPAR RETROCESSION QUOTEPART QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE BONUS AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## BONUS formula
@@ -1308,11 +965,11 @@ program: OPERATION LABEL PAR LIDENT BONUS DATE SUR
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT AVANT VERS
+program: OPERATION PAR LIDENT AVANT VERS
 ##
-## Ends in an error in state: 128.
+## Ends in an error in state: 127.
 ##
-## before_expr(simple_exprs) -> AVANT . event_expr sub_expression(simple_exprs) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## before_expr(simple_exprs) -> AVANT . event_expr sub_expression(simple_exprs) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## AVANT
@@ -1320,11 +977,11 @@ program: OPERATION LABEL PAR LIDENT AVANT VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT AVANT EVENEMENT LIDENT VALEUR
+program: OPERATION PAR LIDENT AVANT EVENEMENT LIDENT VERS
 ##
-## Ends in an error in state: 129.
+## Ends in an error in state: 128.
 ##
-## before_expr(simple_exprs) -> AVANT event_expr . sub_expression(simple_exprs) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## before_expr(simple_exprs) -> AVANT event_expr . sub_expression(simple_exprs) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
 ## event_expr_desc -> event_expr . ET event_expr [ RETROCESSION QUOTEPART OU LPAR ET BONUS ]
 ## event_expr_desc -> event_expr . OU event_expr [ RETROCESSION QUOTEPART OU LPAR ET BONUS ]
 ##
@@ -1334,12 +991,12 @@ program: OPERATION LABEL PAR LIDENT AVANT EVENEMENT LIDENT VALEUR
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT BONUS DATE VERS LIDENT VERS
+program: OPERATION PAR LIDENT BONUS DATE VERS LIDENT LPAR
 ##
-## Ends in an error in state: 132.
+## Ends in an error in state: 131.
 ##
-## nonempty_list(simple_expr) -> simple_expr . [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
-## nonempty_list(simple_expr) -> simple_expr . nonempty_list(simple_expr) [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## nonempty_list(simple_expr) -> simple_expr . [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
+## nonempty_list(simple_expr) -> simple_expr . nonempty_list(simple_expr) [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## simple_expr
@@ -1350,19 +1007,19 @@ program: OPERATION LABEL PAR LIDENT BONUS DATE VERS LIDENT VERS
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 64, spurious reduction of production actor_desc -> LIDENT
 ## In state 66, spurious reduction of production actor -> actor_desc
-## In state 77, spurious reduction of production holder -> actor
-## In state 76, spurious reduction of production destinataire -> VERS holder
-## In state 103, spurious reduction of production option(destinataire) -> destinataire
-## In state 127, spurious reduction of production simple_expr -> BONUS formula option(destinataire)
+## In state 76, spurious reduction of production holder -> actor
+## In state 75, spurious reduction of production destinataire -> VERS holder
+## In state 102, spurious reduction of production option(destinataire) -> destinataire
+## In state 126, spurious reduction of production simple_expr -> BONUS formula option(destinataire)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT APRES VERS
+program: OPERATION PAR LIDENT APRES VERS
 ##
-## Ends in an error in state: 135.
+## Ends in an error in state: 134.
 ##
-## after_expr(simple_exprs) -> APRES . event_expr sub_expression(simple_exprs) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE APRES ACTEUR ]
+## after_expr(simple_exprs) -> APRES . event_expr sub_expression(simple_exprs) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## APRES
@@ -1370,11 +1027,11 @@ program: OPERATION LABEL PAR LIDENT APRES VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT APRES EVENEMENT LIDENT VALEUR
+program: OPERATION PAR LIDENT APRES EVENEMENT LIDENT VERS
 ##
-## Ends in an error in state: 136.
+## Ends in an error in state: 135.
 ##
-## after_expr(simple_exprs) -> APRES event_expr . sub_expression(simple_exprs) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE APRES ACTEUR ]
+## after_expr(simple_exprs) -> APRES event_expr . sub_expression(simple_exprs) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE APRES ACTEUR ]
 ## event_expr_desc -> event_expr . ET event_expr [ RETROCESSION QUOTEPART OU LPAR ET BONUS ]
 ## event_expr_desc -> event_expr . OU event_expr [ RETROCESSION QUOTEPART OU LPAR ET BONUS ]
 ##
@@ -1384,12 +1041,12 @@ program: OPERATION LABEL PAR LIDENT APRES EVENEMENT LIDENT VALEUR
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT QUAND EVENEMENT LIDENT BONUS DATE AVANT
+program: OPERATION PAR LIDENT QUAND EVENEMENT LIDENT BONUS DATE AVANT
 ##
-## Ends in an error in state: 138.
+## Ends in an error in state: 137.
 ##
-## nonempty_list(when_expr(simple_exprs)) -> when_expr(simple_exprs) . [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## nonempty_list(when_expr(simple_exprs)) -> when_expr(simple_exprs) . nonempty_list(when_expr(simple_exprs)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## nonempty_list(when_expr(simple_exprs)) -> when_expr(simple_exprs) . [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+## nonempty_list(when_expr(simple_exprs)) -> when_expr(simple_exprs) . nonempty_list(when_expr(simple_exprs)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## when_expr(simple_exprs)
@@ -1398,21 +1055,21 @@ program: OPERATION LABEL PAR LIDENT QUAND EVENEMENT LIDENT BONUS DATE AVANT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 126, spurious reduction of production option(destinataire) ->
-## In state 127, spurious reduction of production simple_expr -> BONUS formula option(destinataire)
-## In state 132, spurious reduction of production nonempty_list(simple_expr) -> simple_expr
-## In state 134, spurious reduction of production simple_exprs -> nonempty_list(simple_expr)
-## In state 131, spurious reduction of production sub_expression(simple_exprs) -> simple_exprs
-## In state 154, spurious reduction of production when_expr(simple_exprs) -> QUAND event_expr sub_expression(simple_exprs)
+## In state 125, spurious reduction of production option(destinataire) ->
+## In state 126, spurious reduction of production simple_expr -> BONUS formula option(destinataire)
+## In state 131, spurious reduction of production nonempty_list(simple_expr) -> simple_expr
+## In state 133, spurious reduction of production simple_exprs -> nonempty_list(simple_expr)
+## In state 130, spurious reduction of production sub_expression(simple_exprs) -> simple_exprs
+## In state 153, spurious reduction of production when_expr(simple_exprs) -> QUAND event_expr sub_expression(simple_exprs)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT AVANT EVENEMENT LIDENT BONUS DATE APRES EVENEMENT LIDENT BONUS DATE QUAND
+program: OPERATION PAR LIDENT AVANT EVENEMENT LIDENT BONUS DATE APRES EVENEMENT LIDENT BONUS DATE QUAND
 ##
-## Ends in an error in state: 144.
+## Ends in an error in state: 143.
 ##
-## list(after_expr(simple_exprs)) -> after_expr(simple_exprs) . list(after_expr(simple_exprs)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## list(after_expr(simple_exprs)) -> after_expr(simple_exprs) . list(after_expr(simple_exprs)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## after_expr(simple_exprs)
@@ -1421,21 +1078,21 @@ program: OPERATION LABEL PAR LIDENT AVANT EVENEMENT LIDENT BONUS DATE APRES EVEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 126, spurious reduction of production option(destinataire) ->
-## In state 127, spurious reduction of production simple_expr -> BONUS formula option(destinataire)
-## In state 132, spurious reduction of production nonempty_list(simple_expr) -> simple_expr
-## In state 134, spurious reduction of production simple_exprs -> nonempty_list(simple_expr)
-## In state 131, spurious reduction of production sub_expression(simple_exprs) -> simple_exprs
-## In state 137, spurious reduction of production after_expr(simple_exprs) -> APRES event_expr sub_expression(simple_exprs)
+## In state 125, spurious reduction of production option(destinataire) ->
+## In state 126, spurious reduction of production simple_expr -> BONUS formula option(destinataire)
+## In state 131, spurious reduction of production nonempty_list(simple_expr) -> simple_expr
+## In state 133, spurious reduction of production simple_exprs -> nonempty_list(simple_expr)
+## In state 130, spurious reduction of production sub_expression(simple_exprs) -> simple_exprs
+## In state 136, spurious reduction of production after_expr(simple_exprs) -> APRES event_expr sub_expression(simple_exprs)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT APRES EVENEMENT LIDENT LPAR BONUS DATE VALEUR
+program: OPERATION PAR LIDENT APRES EVENEMENT LIDENT LPAR BONUS DATE QUAND
 ##
-## Ends in an error in state: 147.
+## Ends in an error in state: 146.
 ##
-## sub_expression(simple_exprs) -> LPAR expression(simple_exprs) . RPAR [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## sub_expression(simple_exprs) -> LPAR expression(simple_exprs) . RPAR [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAR expression(simple_exprs)
@@ -1444,21 +1101,21 @@ program: OPERATION LABEL PAR LIDENT APRES EVENEMENT LIDENT LPAR BONUS DATE VALEU
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 126, spurious reduction of production option(destinataire) ->
-## In state 127, spurious reduction of production simple_expr -> BONUS formula option(destinataire)
-## In state 132, spurious reduction of production nonempty_list(simple_expr) -> simple_expr
-## In state 134, spurious reduction of production simple_exprs -> nonempty_list(simple_expr)
-## In state 140, spurious reduction of production expression(simple_exprs) -> simple_exprs
+## In state 125, spurious reduction of production option(destinataire) ->
+## In state 126, spurious reduction of production simple_expr -> BONUS formula option(destinataire)
+## In state 131, spurious reduction of production nonempty_list(simple_expr) -> simple_expr
+## In state 133, spurious reduction of production simple_exprs -> nonempty_list(simple_expr)
+## In state 139, spurious reduction of production expression(simple_exprs) -> simple_exprs
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT AVANT EVENEMENT LIDENT BONUS DATE QUAND
+program: OPERATION PAR LIDENT AVANT EVENEMENT LIDENT BONUS DATE QUAND
 ##
-## Ends in an error in state: 150.
+## Ends in an error in state: 149.
 ##
-## nonempty_list(before_expr(simple_exprs)) -> before_expr(simple_exprs) . [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE APRES ACTEUR ]
-## nonempty_list(before_expr(simple_exprs)) -> before_expr(simple_exprs) . nonempty_list(before_expr(simple_exprs)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE APRES ACTEUR ]
+## nonempty_list(before_expr(simple_exprs)) -> before_expr(simple_exprs) . [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE APRES ACTEUR ]
+## nonempty_list(before_expr(simple_exprs)) -> before_expr(simple_exprs) . nonempty_list(before_expr(simple_exprs)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## before_expr(simple_exprs)
@@ -1467,22 +1124,22 @@ program: OPERATION LABEL PAR LIDENT AVANT EVENEMENT LIDENT BONUS DATE QUAND
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 126, spurious reduction of production option(destinataire) ->
-## In state 127, spurious reduction of production simple_expr -> BONUS formula option(destinataire)
-## In state 132, spurious reduction of production nonempty_list(simple_expr) -> simple_expr
-## In state 134, spurious reduction of production simple_exprs -> nonempty_list(simple_expr)
-## In state 131, spurious reduction of production sub_expression(simple_exprs) -> simple_exprs
-## In state 130, spurious reduction of production before_expr(simple_exprs) -> AVANT event_expr sub_expression(simple_exprs)
+## In state 125, spurious reduction of production option(destinataire) ->
+## In state 126, spurious reduction of production simple_expr -> BONUS formula option(destinataire)
+## In state 131, spurious reduction of production nonempty_list(simple_expr) -> simple_expr
+## In state 133, spurious reduction of production simple_exprs -> nonempty_list(simple_expr)
+## In state 130, spurious reduction of production sub_expression(simple_exprs) -> simple_exprs
+## In state 129, spurious reduction of production before_expr(simple_exprs) -> AVANT event_expr sub_expression(simple_exprs)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: OPERATION LABEL PAR LIDENT APRES EVENEMENT LIDENT BONUS DATE QUAND
+program: OPERATION PAR LIDENT APRES EVENEMENT LIDENT BONUS DATE QUAND
 ##
-## Ends in an error in state: 152.
+## Ends in an error in state: 151.
 ##
-## nonempty_list(after_expr(simple_exprs)) -> after_expr(simple_exprs) . [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## nonempty_list(after_expr(simple_exprs)) -> after_expr(simple_exprs) . nonempty_list(after_expr(simple_exprs)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## nonempty_list(after_expr(simple_exprs)) -> after_expr(simple_exprs) . [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+## nonempty_list(after_expr(simple_exprs)) -> after_expr(simple_exprs) . nonempty_list(after_expr(simple_exprs)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## after_expr(simple_exprs)
@@ -1491,21 +1148,120 @@ program: OPERATION LABEL PAR LIDENT APRES EVENEMENT LIDENT BONUS DATE QUAND
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 126, spurious reduction of production option(destinataire) ->
-## In state 127, spurious reduction of production simple_expr -> BONUS formula option(destinataire)
-## In state 132, spurious reduction of production nonempty_list(simple_expr) -> simple_expr
-## In state 134, spurious reduction of production simple_exprs -> nonempty_list(simple_expr)
-## In state 131, spurious reduction of production sub_expression(simple_exprs) -> simple_exprs
-## In state 137, spurious reduction of production after_expr(simple_exprs) -> APRES event_expr sub_expression(simple_exprs)
+## In state 125, spurious reduction of production option(destinataire) ->
+## In state 126, spurious reduction of production simple_expr -> BONUS formula option(destinataire)
+## In state 131, spurious reduction of production nonempty_list(simple_expr) -> simple_expr
+## In state 133, spurious reduction of production simple_exprs -> nonempty_list(simple_expr)
+## In state 130, spurious reduction of production sub_expression(simple_exprs) -> simple_exprs
+## In state 136, spurious reduction of production after_expr(simple_exprs) -> APRES event_expr sub_expression(simple_exprs)
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: EVENEMENT VERS
+##
+## Ends in an error in state: 155.
+##
+## event_decl -> EVENEMENT . LIDENT ATTEINT QUAND event_expr [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## EVENEMENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: EVENEMENT LIDENT VERS
+##
+## Ends in an error in state: 156.
+##
+## event_decl -> EVENEMENT LIDENT . ATTEINT QUAND event_expr [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## EVENEMENT LIDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: EVENEMENT LIDENT ATTEINT VERS
+##
+## Ends in an error in state: 157.
+##
+## event_decl -> EVENEMENT LIDENT ATTEINT . QUAND event_expr [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## EVENEMENT LIDENT ATTEINT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: EVENEMENT LIDENT ATTEINT QUAND VERS
+##
+## Ends in an error in state: 158.
+##
+## event_decl -> EVENEMENT LIDENT ATTEINT QUAND . event_expr [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## EVENEMENT LIDENT ATTEINT QUAND
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: EVENEMENT LIDENT ATTEINT QUAND EVENEMENT LIDENT LPAR
+##
+## Ends in an error in state: 159.
+##
+## event_decl -> EVENEMENT LIDENT ATTEINT QUAND event_expr . [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+## event_expr_desc -> event_expr . ET event_expr [ VALEUR OU OPERATION EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+## event_expr_desc -> event_expr . OU event_expr [ VALEUR OU OPERATION EVENEMENT ET EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## EVENEMENT LIDENT ATTEINT QUAND event_expr
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: ENTREE VERS
+##
+## Ends in an error in state: 160.
+##
+## input_decl -> ENTREE . LIDENT input_type loption(input_context_decl) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+## input_decl -> ENTREE . ASSIETTE LIDENT loption(input_context_decl) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## ENTREE
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: ENTREE LIDENT VERS
+##
+## Ends in an error in state: 161.
+##
+## input_decl -> ENTREE LIDENT . input_type loption(input_context_decl) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## ENTREE LIDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: ENTREE LIDENT TYPE VERS
+##
+## Ends in an error in state: 162.
+##
+## input_type -> TYPE . base_type [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTUALISEE CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## TYPE
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENTREE LIDENT TYPE ARGENT VERS
 ##
-## Ends in an error in state: 168.
+## Ends in an error in state: 167.
 ##
-## input_decl -> ENTREE LIDENT input_type . loption(input_context_decl) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## input_decl -> ENTREE LIDENT input_type . loption(input_context_decl) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## ENTREE LIDENT input_type
@@ -1515,9 +1271,9 @@ program: ENTREE LIDENT TYPE ARGENT VERS
 
 program: ENTREE ASSIETTE LIDENT CONTEXTUALISEE VERS
 ##
-## Ends in an error in state: 169.
+## Ends in an error in state: 168.
 ##
-## input_context_decl -> CONTEXTUALISEE . PAR input_context_list [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## input_context_decl -> CONTEXTUALISEE . PAR input_context_list [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXTUALISEE
@@ -1527,9 +1283,9 @@ program: ENTREE ASSIETTE LIDENT CONTEXTUALISEE VERS
 
 program: ENTREE ASSIETTE LIDENT CONTEXTUALISEE PAR VERS
 ##
-## Ends in an error in state: 170.
+## Ends in an error in state: 169.
 ##
-## input_context_decl -> CONTEXTUALISEE PAR . input_context_list [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## input_context_decl -> CONTEXTUALISEE PAR . input_context_list [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXTUALISEE PAR
@@ -1539,10 +1295,10 @@ program: ENTREE ASSIETTE LIDENT CONTEXTUALISEE PAR VERS
 
 program: ENTREE ASSIETTE LIDENT CONTEXTUALISEE PAR MINUS VERS
 ##
-## Ends in an error in state: 171.
+## Ends in an error in state: 170.
 ##
-## nonempty_list(preceded(MINUS,input_context)) -> MINUS . input_context [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## nonempty_list(preceded(MINUS,input_context)) -> MINUS . input_context nonempty_list(preceded(MINUS,input_context)) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## nonempty_list(preceded(MINUS,input_context)) -> MINUS . input_context [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+## nonempty_list(preceded(MINUS,input_context)) -> MINUS . input_context nonempty_list(preceded(MINUS,input_context)) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## MINUS
@@ -1552,10 +1308,10 @@ program: ENTREE ASSIETTE LIDENT CONTEXTUALISEE PAR MINUS VERS
 
 program: ENTREE ASSIETTE LIDENT CONTEXTUALISEE PAR TOUT UIDENT VERS
 ##
-## Ends in an error in state: 175.
+## Ends in an error in state: 174.
 ##
-## nonempty_list(context) -> context . [ VALEUR OPERATION MINUS EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## nonempty_list(context) -> context . nonempty_list(context) [ VALEUR OPERATION MINUS EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## nonempty_list(context) -> context . [ VALEUR OPERATION MINUS EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+## nonempty_list(context) -> context . nonempty_list(context) [ VALEUR OPERATION MINUS EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## context
@@ -1565,9 +1321,9 @@ program: ENTREE ASSIETTE LIDENT CONTEXTUALISEE PAR TOUT UIDENT VERS
 
 program: ENTREE ASSIETTE VERS
 ##
-## Ends in an error in state: 182.
+## Ends in an error in state: 181.
 ##
-## input_decl -> ENTREE ASSIETTE . LIDENT loption(input_context_decl) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## input_decl -> ENTREE ASSIETTE . LIDENT loption(input_context_decl) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## ENTREE ASSIETTE
@@ -1577,9 +1333,9 @@ program: ENTREE ASSIETTE VERS
 
 program: ENTREE ASSIETTE LIDENT VERS
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 182.
 ##
-## input_decl -> ENTREE ASSIETTE LIDENT . loption(input_context_decl) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## input_decl -> ENTREE ASSIETTE LIDENT . loption(input_context_decl) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## ENTREE ASSIETTE LIDENT
@@ -1587,11 +1343,23 @@ program: ENTREE ASSIETTE LIDENT VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+program: DEFICIT VERS
+##
+## Ends in an error in state: 184.
+##
+## deficit_decl -> DEFICIT . SUR pool PAR holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## DEFICIT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 program: DEFICIT SUR VERS
 ##
-## Ends in an error in state: 186.
+## Ends in an error in state: 185.
 ##
-## deficit_decl -> DEFICIT SUR . pool PAR holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## deficit_decl -> DEFICIT SUR . pool PAR holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## DEFICIT SUR
@@ -1599,11 +1367,54 @@ program: DEFICIT SUR VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+program: DEFICIT SUR ASSIETTE LIDENT VERS
+##
+## Ends in an error in state: 186.
+##
+## deficit_decl -> DEFICIT SUR pool . PAR holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## DEFICIT SUR pool
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 17, spurious reduction of production raw_pool -> LIDENT
+## In state 19, spurious reduction of production pool -> ASSIETTE raw_pool
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: DEFICIT SUR ASSIETTE LIDENT PAR VERS
+##
+## Ends in an error in state: 187.
+##
+## deficit_decl -> DEFICIT SUR pool PAR . holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## DEFICIT SUR pool PAR
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: DEFAUT VERS
+##
+## Ends in an error in state: 189.
+##
+## default_decl -> DEFAUT . SUR pool VERS holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## DEFAUT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 program: DEFAUT SUR VERS
 ##
-## Ends in an error in state: 191.
+## Ends in an error in state: 190.
 ##
-## default_decl -> DEFAUT SUR . pool VERS holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## default_decl -> DEFAUT SUR . pool VERS holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## DEFAUT SUR
@@ -1613,9 +1424,9 @@ program: DEFAUT SUR VERS
 
 program: DEFAUT SUR ASSIETTE LIDENT VALEUR
 ##
-## Ends in an error in state: 192.
+## Ends in an error in state: 191.
 ##
-## default_decl -> DEFAUT SUR pool . VERS holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## default_decl -> DEFAUT SUR pool . VERS holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## DEFAUT SUR pool
@@ -1630,73 +1441,120 @@ program: DEFAUT SUR ASSIETTE LIDENT VALEUR
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: AVANCE LABEL SUR VERS
+program: DEFAUT SUR ASSIETTE LIDENT VERS VERS
 ##
-## Ends in an error in state: 209.
+## Ends in an error in state: 192.
 ##
-## advance -> AVANCE LABEL SUR . holder PAR actor MONTANT formula [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## default_decl -> DEFAUT SUR pool VERS . holder [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
-## AVANCE LABEL SUR
+## DEFAUT SUR pool VERS
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: AVANCE LABEL SUR LIDENT PAR LIDENT VERS
+program: CONTEXTE VERS
 ##
-## Ends in an error in state: 212.
+## Ends in an error in state: 194.
 ##
-## advance -> AVANCE LABEL SUR holder PAR actor . MONTANT formula [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## context_decl -> CONTEXTE . UIDENT COLON nonempty_list(context_case) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
-## AVANCE LABEL SUR holder PAR actor
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 64, spurious reduction of production actor_desc -> LIDENT
-## In state 66, spurious reduction of production actor -> actor_desc
+## CONTEXTE
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: AVANCE LABEL SUR LIDENT PAR LIDENT MONTANT VERS
+program: CONTEXTE UIDENT VERS
 ##
-## Ends in an error in state: 213.
+## Ends in an error in state: 195.
 ##
-## advance -> AVANCE LABEL SUR holder PAR actor MONTANT . formula [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## context_decl -> CONTEXTE UIDENT . COLON nonempty_list(context_case) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
-## AVANCE LABEL SUR holder PAR actor MONTANT
+## CONTEXTE UIDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: AVANCE LABEL SUR LIDENT PAR LIDENT MONTANT DATE VERS
+program: CONTEXTE UIDENT COLON VERS
 ##
-## Ends in an error in state: 214.
+## Ends in an error in state: 196.
 ##
-## advance -> AVANCE LABEL SUR holder PAR actor MONTANT formula . [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . PLUS formula [ VALEUR TOTAL PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . MINUS formula [ VALEUR TOTAL PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . MULT formula [ VALEUR TOTAL PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . DIV formula [ VALEUR TOTAL PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . COURANT [ VALEUR TOTAL PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . TOTAL [ VALEUR TOTAL PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## formula_desc -> formula . opposable [ VALEUR TOTAL PLUS OPPOSABLE OPERATION MULT MINUS EVENEMENT EOF ENTREE DIV DEFICIT DEFAUT COURANT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## context_decl -> CONTEXTE UIDENT COLON . nonempty_list(context_case) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
-## AVANCE LABEL SUR holder PAR actor MONTANT formula
+## CONTEXTE UIDENT COLON
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: CONTEXTE UIDENT COLON MINUS VERS
+##
+## Ends in an error in state: 197.
+##
+## context_case -> MINUS . UIDENT [ VALEUR OPERATION MINUS EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## MINUS
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: CONTEXTE UIDENT COLON MINUS UIDENT VERS
+##
+## Ends in an error in state: 200.
+##
+## nonempty_list(context_case) -> context_case . [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+## nonempty_list(context_case) -> context_case . nonempty_list(context_case) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## context_case
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: CONSTANTE VERS
+##
+## Ends in an error in state: 202.
+##
+## constant_decl -> CONSTANTE . LIDENT COLON literal [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## CONSTANTE
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: CONSTANTE LIDENT VERS
+##
+## Ends in an error in state: 203.
+##
+## constant_decl -> CONSTANTE LIDENT . COLON literal [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## CONSTANTE LIDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: CONSTANTE LIDENT COLON VERS
+##
+## Ends in an error in state: 204.
+##
+## constant_decl -> CONSTANTE LIDENT COLON . literal [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+##
+## The known suffix of the stack is as follows:
+## CONSTANTE LIDENT COLON
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ASSIETTE VERS
 ##
-## Ends in an error in state: 215.
+## Ends in an error in state: 206.
 ##
-## comp_pool_decl -> ASSIETTE . CALCULEE LIDENT list(op_context) expression(value_def) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## comp_pool_decl -> ASSIETTE . CALCULEE LIDENT list(op_context) expression(value_def) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## ASSIETTE
@@ -1706,9 +1564,9 @@ program: ASSIETTE VERS
 
 program: ASSIETTE CALCULEE VERS
 ##
-## Ends in an error in state: 216.
+## Ends in an error in state: 207.
 ##
-## comp_pool_decl -> ASSIETTE CALCULEE . LIDENT list(op_context) expression(value_def) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## comp_pool_decl -> ASSIETTE CALCULEE . LIDENT list(op_context) expression(value_def) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## ASSIETTE CALCULEE
@@ -1718,9 +1576,9 @@ program: ASSIETTE CALCULEE VERS
 
 program: ASSIETTE CALCULEE LIDENT VERS
 ##
-## Ends in an error in state: 217.
+## Ends in an error in state: 208.
 ##
-## comp_pool_decl -> ASSIETTE CALCULEE LIDENT . list(op_context) expression(value_def) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## comp_pool_decl -> ASSIETTE CALCULEE LIDENT . list(op_context) expression(value_def) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## ASSIETTE CALCULEE LIDENT
@@ -1730,9 +1588,9 @@ program: ASSIETTE CALCULEE LIDENT VERS
 
 program: ASSIETTE CALCULEE LIDENT POUR TOUT UIDENT SUR
 ##
-## Ends in an error in state: 218.
+## Ends in an error in state: 209.
 ##
-## comp_pool_decl -> ASSIETTE CALCULEE LIDENT list(op_context) . expression(value_def) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## comp_pool_decl -> ASSIETTE CALCULEE LIDENT list(op_context) . expression(value_def) [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## ASSIETTE CALCULEE LIDENT list(op_context)
@@ -1741,17 +1599,17 @@ program: ASSIETTE CALCULEE LIDENT POUR TOUT UIDENT SUR
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 90, spurious reduction of production list(op_context) ->
-## In state 91, spurious reduction of production list(op_context) -> op_context list(op_context)
+## In state 89, spurious reduction of production list(op_context) ->
+## In state 90, spurious reduction of production list(op_context) -> op_context list(op_context)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ASSIETTE CALCULEE LIDENT QUAND VERS
 ##
-## Ends in an error in state: 219.
+## Ends in an error in state: 210.
 ##
-## when_expr(value_def) -> QUAND . event_expr sub_expression(value_def) [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## when_expr(value_def) -> QUAND . event_expr sub_expression(value_def) [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## QUAND
@@ -1759,13 +1617,13 @@ program: ASSIETTE CALCULEE LIDENT QUAND VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: ASSIETTE CALCULEE LIDENT QUAND EVENEMENT LIDENT VALEUR
+program: ASSIETTE CALCULEE LIDENT QUAND EVENEMENT LIDENT VERS
 ##
-## Ends in an error in state: 220.
+## Ends in an error in state: 211.
 ##
 ## event_expr_desc -> event_expr . ET event_expr [ OU LPAR ET COLON ]
 ## event_expr_desc -> event_expr . OU event_expr [ OU LPAR ET COLON ]
-## when_expr(value_def) -> QUAND event_expr . sub_expression(value_def) [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## when_expr(value_def) -> QUAND event_expr . sub_expression(value_def) [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## QUAND event_expr
@@ -1775,9 +1633,9 @@ program: ASSIETTE CALCULEE LIDENT QUAND EVENEMENT LIDENT VALEUR
 
 program: ASSIETTE CALCULEE LIDENT APRES EVENEMENT LIDENT LPAR VERS
 ##
-## Ends in an error in state: 221.
+## Ends in an error in state: 212.
 ##
-## sub_expression(value_def) -> LPAR . expression(value_def) RPAR [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## sub_expression(value_def) -> LPAR . expression(value_def) RPAR [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAR
@@ -1787,9 +1645,9 @@ program: ASSIETTE CALCULEE LIDENT APRES EVENEMENT LIDENT LPAR VERS
 
 program: ASSIETTE CALCULEE LIDENT AVANT VERS
 ##
-## Ends in an error in state: 222.
+## Ends in an error in state: 213.
 ##
-## before_expr(value_def) -> AVANT . event_expr sub_expression(value_def) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## before_expr(value_def) -> AVANT . event_expr sub_expression(value_def) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## AVANT
@@ -1797,11 +1655,11 @@ program: ASSIETTE CALCULEE LIDENT AVANT VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: ASSIETTE CALCULEE LIDENT AVANT EVENEMENT LIDENT VALEUR
+program: ASSIETTE CALCULEE LIDENT AVANT EVENEMENT LIDENT VERS
 ##
-## Ends in an error in state: 223.
+## Ends in an error in state: 214.
 ##
-## before_expr(value_def) -> AVANT event_expr . sub_expression(value_def) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## before_expr(value_def) -> AVANT event_expr . sub_expression(value_def) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
 ## event_expr_desc -> event_expr . ET event_expr [ OU LPAR ET COLON ]
 ## event_expr_desc -> event_expr . OU event_expr [ OU LPAR ET COLON ]
 ##
@@ -1813,9 +1671,9 @@ program: ASSIETTE CALCULEE LIDENT AVANT EVENEMENT LIDENT VALEUR
 
 program: ASSIETTE CALCULEE LIDENT APRES VERS
 ##
-## Ends in an error in state: 226.
+## Ends in an error in state: 217.
 ##
-## after_expr(value_def) -> APRES . event_expr sub_expression(value_def) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE APRES ACTEUR ]
+## after_expr(value_def) -> APRES . event_expr sub_expression(value_def) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## APRES
@@ -1823,11 +1681,11 @@ program: ASSIETTE CALCULEE LIDENT APRES VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: ASSIETTE CALCULEE LIDENT APRES EVENEMENT LIDENT VALEUR
+program: ASSIETTE CALCULEE LIDENT APRES EVENEMENT LIDENT VERS
 ##
-## Ends in an error in state: 227.
+## Ends in an error in state: 218.
 ##
-## after_expr(value_def) -> APRES event_expr . sub_expression(value_def) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE APRES ACTEUR ]
+## after_expr(value_def) -> APRES event_expr . sub_expression(value_def) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE APRES ACTEUR ]
 ## event_expr_desc -> event_expr . ET event_expr [ OU LPAR ET COLON ]
 ## event_expr_desc -> event_expr . OU event_expr [ OU LPAR ET COLON ]
 ##
@@ -1839,10 +1697,10 @@ program: ASSIETTE CALCULEE LIDENT APRES EVENEMENT LIDENT VALEUR
 
 program: ASSIETTE CALCULEE LIDENT QUAND EVENEMENT LIDENT COLON DATE AVANT
 ##
-## Ends in an error in state: 229.
+## Ends in an error in state: 220.
 ##
-## nonempty_list(when_expr(value_def)) -> when_expr(value_def) . [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## nonempty_list(when_expr(value_def)) -> when_expr(value_def) . nonempty_list(when_expr(value_def)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## nonempty_list(when_expr(value_def)) -> when_expr(value_def) . [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+## nonempty_list(when_expr(value_def)) -> when_expr(value_def) . nonempty_list(when_expr(value_def)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## when_expr(value_def)
@@ -1852,17 +1710,17 @@ program: ASSIETTE CALCULEE LIDENT QUAND EVENEMENT LIDENT COLON DATE AVANT
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 70, spurious reduction of production value_def -> COLON formula
-## In state 224, spurious reduction of production sub_expression(value_def) -> value_def
-## In state 245, spurious reduction of production when_expr(value_def) -> QUAND event_expr sub_expression(value_def)
+## In state 215, spurious reduction of production sub_expression(value_def) -> value_def
+## In state 236, spurious reduction of production when_expr(value_def) -> QUAND event_expr sub_expression(value_def)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ASSIETTE CALCULEE LIDENT AVANT EVENEMENT LIDENT COLON DATE APRES EVENEMENT LIDENT COLON DATE QUAND
 ##
-## Ends in an error in state: 235.
+## Ends in an error in state: 226.
 ##
-## list(after_expr(value_def)) -> after_expr(value_def) . list(after_expr(value_def)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## list(after_expr(value_def)) -> after_expr(value_def) . list(after_expr(value_def)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## after_expr(value_def)
@@ -1872,17 +1730,17 @@ program: ASSIETTE CALCULEE LIDENT AVANT EVENEMENT LIDENT COLON DATE APRES EVENEM
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 70, spurious reduction of production value_def -> COLON formula
-## In state 224, spurious reduction of production sub_expression(value_def) -> value_def
-## In state 228, spurious reduction of production after_expr(value_def) -> APRES event_expr sub_expression(value_def)
+## In state 215, spurious reduction of production sub_expression(value_def) -> value_def
+## In state 219, spurious reduction of production after_expr(value_def) -> APRES event_expr sub_expression(value_def)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: ASSIETTE CALCULEE LIDENT APRES EVENEMENT LIDENT LPAR COLON DATE VALEUR
+program: ASSIETTE CALCULEE LIDENT APRES EVENEMENT LIDENT LPAR COLON DATE QUAND
 ##
-## Ends in an error in state: 238.
+## Ends in an error in state: 229.
 ##
-## sub_expression(value_def) -> LPAR expression(value_def) . RPAR [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT AVANCE ASSIETTE APRES ACTEUR ]
+## sub_expression(value_def) -> LPAR expression(value_def) . RPAR [ VALEUR RPAR QUAND OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANT ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAR expression(value_def)
@@ -1892,17 +1750,17 @@ program: ASSIETTE CALCULEE LIDENT APRES EVENEMENT LIDENT LPAR COLON DATE VALEUR
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 70, spurious reduction of production value_def -> COLON formula
-## In state 231, spurious reduction of production expression(value_def) -> value_def
+## In state 222, spurious reduction of production expression(value_def) -> value_def
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ASSIETTE CALCULEE LIDENT AVANT EVENEMENT LIDENT COLON DATE QUAND
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 232.
 ##
-## nonempty_list(before_expr(value_def)) -> before_expr(value_def) . [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE APRES ACTEUR ]
-## nonempty_list(before_expr(value_def)) -> before_expr(value_def) . nonempty_list(before_expr(value_def)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE APRES ACTEUR ]
+## nonempty_list(before_expr(value_def)) -> before_expr(value_def) . [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE APRES ACTEUR ]
+## nonempty_list(before_expr(value_def)) -> before_expr(value_def) . nonempty_list(before_expr(value_def)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE APRES ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## before_expr(value_def)
@@ -1912,18 +1770,18 @@ program: ASSIETTE CALCULEE LIDENT AVANT EVENEMENT LIDENT COLON DATE QUAND
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 70, spurious reduction of production value_def -> COLON formula
-## In state 224, spurious reduction of production sub_expression(value_def) -> value_def
-## In state 225, spurious reduction of production before_expr(value_def) -> AVANT event_expr sub_expression(value_def)
+## In state 215, spurious reduction of production sub_expression(value_def) -> value_def
+## In state 216, spurious reduction of production before_expr(value_def) -> AVANT event_expr sub_expression(value_def)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ASSIETTE CALCULEE LIDENT APRES EVENEMENT LIDENT COLON DATE QUAND
 ##
-## Ends in an error in state: 243.
+## Ends in an error in state: 234.
 ##
-## nonempty_list(after_expr(value_def)) -> after_expr(value_def) . [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
-## nonempty_list(after_expr(value_def)) -> after_expr(value_def) . nonempty_list(after_expr(value_def)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## nonempty_list(after_expr(value_def)) -> after_expr(value_def) . [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
+## nonempty_list(after_expr(value_def)) -> after_expr(value_def) . nonempty_list(after_expr(value_def)) [ VALEUR RPAR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## after_expr(value_def)
@@ -1933,17 +1791,17 @@ program: ASSIETTE CALCULEE LIDENT APRES EVENEMENT LIDENT COLON DATE QUAND
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 70, spurious reduction of production value_def -> COLON formula
-## In state 224, spurious reduction of production sub_expression(value_def) -> value_def
-## In state 228, spurious reduction of production after_expr(value_def) -> APRES event_expr sub_expression(value_def)
+## In state 215, spurious reduction of production sub_expression(value_def) -> value_def
+## In state 219, spurious reduction of production after_expr(value_def) -> APRES event_expr sub_expression(value_def)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ACTEUR VERS
 ##
-## Ends in an error in state: 247.
+## Ends in an error in state: 238.
 ##
-## actor_decl -> ACTEUR . LIDENT [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE AVANCE ASSIETTE ACTEUR ]
+## actor_decl -> ACTEUR . LIDENT [ VALEUR OPERATION EVENEMENT EOF ENTREE DEFICIT DEFAUT CONTEXTE CONSTANTE ASSIETTE ACTEUR ]
 ##
 ## The known suffix of the stack is as follows:
 ## ACTEUR
@@ -1951,9 +1809,9 @@ program: ACTEUR VERS
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: ACTEUR LIDENT RPAR
+program: ACTEUR LIDENT UIDENT
 ##
-## Ends in an error in state: 250.
+## Ends in an error in state: 241.
 ##
 ## list(toplevel_decl) -> toplevel_decl . list(toplevel_decl) [ EOF ]
 ##
@@ -1965,7 +1823,7 @@ program: ACTEUR LIDENT RPAR
 
 raw_pool_start: VERS
 ##
-## Ends in an error in state: 265.
+## Ends in an error in state: 255.
 ##
 ## raw_pool_start' -> . raw_pool_start [ # ]
 ##
@@ -1977,7 +1835,7 @@ raw_pool_start: VERS
 
 raw_pool_start: LIDENT VERS
 ##
-## Ends in an error in state: 267.
+## Ends in an error in state: 257.
 ##
 ## raw_pool_start -> raw_pool . EOF [ # ]
 ##

--- a/src/grammar/parser.mly
+++ b/src/grammar/parser.mly
@@ -8,11 +8,11 @@ let pos (start, stop) = Pos.Text.make ~start ~stop
 %token CONTEXTUALISEE PAR TYPE ENTIER RATIONNEL ARGENT TOTAL COURANT
 %token ACTEUR POUR EVENEMENT NON ET OU AVANT APRES QUAND CONTEXTE TOUT CONSTANTE
 %token LPAR RPAR VERS ATTEINT PLUS MINUS MULT DIV EQ COLON EOF DEFICIT
-%token AVANCE MONTANT COMMA RETROCESSION RESTE OPPOSABLE ENVERS VALEUR CALCULEE
+%token COMMA RETROCESSION RESTE OPPOSABLE ENVERS VALEUR CALCULEE
 %token OBSERVABLE // SECTION FIN
 %token<R.t> FLOAT
 %token<Z.t> INT MONEY
-%token<string> LIDENT UIDENT LABEL
+%token<string> LIDENT UIDENT
 %token<Date.Date.t> DATE
 
 %nonassoc LIDENT
@@ -32,17 +32,17 @@ let pos (start, stop) = Pos.Text.make ~start ~stop
 // Dispatch
 
 operation:
-| OPERATION op_label = LABEL op_default_dest = destinataire?
+| OPERATION op_default_dest = destinataire?
     op_context = op_context* op_source = source
     exprs = expression(simple_exprs)
 {
   operation_decl
     ~loc:(pos $sloc)
-    op_label
     ?default_dest:op_default_dest
     ~context:op_context
     ~source:op_source
     ~guarded_redistrib:exprs
+    ()
 }
 
 comp_pool_decl:
@@ -65,16 +65,6 @@ value_decl:
 
 value_def:
 | COLON formula = formula { formula }
-
-advance:
-| AVANCE adv_label = LABEL SUR adv_output = holder PAR
-    adv_provider = actor MONTANT adv_amount = formula
-  {{
-      adv_label;
-      adv_output;
-      adv_provider;
-      adv_amount;
-  }}
 
 opposable:
 | OPPOSABLE f = formula ENVERS t = actor PAR p = actor {
@@ -362,7 +352,6 @@ toplevel_decl:
 | d = deficit_decl
   { let (deficit_pool, deficit_provider) = d in
     DHolderDeficit { deficit_pool; deficit_provider } }
-| a = advance { DHolderAdvance a }
 /* | s = section { DSection s } */
 
 program: d = toplevel_decl* EOF { Source d }

--- a/src/interpreter/printer.ml
+++ b/src/interpreter/printer.ml
@@ -40,8 +40,8 @@ let rec print_item ?(close=true) infos fmt layout step (item : Results.top_item)
         let name =
           match Variable.Map.find_opt dest layout with
           | Some (Results.Top item | Detail item) -> item.display_name
-          | Some (Results.Flat item) -> item.flat_name
           | Some (Super item) -> item.super_item.display_name
+          | Some (Results.Flat _) -> "DUMMY" 
           | None ->
             match VarInfo.get_name infos dest with
             | Some name -> name
@@ -82,8 +82,7 @@ let rec print_item ?(close=true) infos fmt layout step (item : Results.top_item)
     (match find_step_value item.value step with
      | Absent -> false
      | Present value ->
-       fprintf fmt "@[<v 2>- %s : %a -> %a"
-         item.flat_name
+       fprintf fmt "@[<v 2>- flat bonus : %a -> %a"
          Value.human_print value
          (fun fmt target ->
             Variable.Map.find_opt target layout

--- a/src/interpreter/results.ml
+++ b/src/interpreter/results.ml
@@ -16,7 +16,6 @@ type item_result_layout = {
 }
 
 type flat_item = {
-  flat_name : string;
   value : Variable.t;
   trigger : Variable.t option;
   target : Variable.t;
@@ -51,7 +50,6 @@ let dummy_detail v = {
 }
 
 let dummy_trigger v tr ta = {
-  flat_name = "%no_name%";
   value = v;
   trigger = tr;
   target = ta;
@@ -143,7 +141,6 @@ let variant_copy (pinfos : ProgramInfo.t) layout
       }
       in
       let copy_flat_item item v = {
-        flat_name = Printf.sprintf "%s @%s" item.flat_name target_name;
         value = v;
         trigger = Option.map variant_if_exists item.trigger;
         target = variant_if_exists item.target;
@@ -266,7 +263,7 @@ let build_result_layout (pinfos : ProgramInfo.t) =
                   layout
               | _ -> assert false), variants
            | _ -> assert false)
-        | OperationDetail { label; op_kind; source; target; condition } ->
+        | OperationDetail {op_kind; source; target; condition } ->
           (match op_kind with
            | Quotepart _ ->
              update_detail_of source (fun l ->
@@ -282,10 +279,7 @@ let build_result_layout (pinfos : ProgramInfo.t) =
                  match condition with When c -> Some c | _ -> None
                in
                update_flat_detail v trigger target (fun l ->
-                   { l with
-                     flat_name =
-                       Option.value label ~default:("flat bonus");
-                   })
+                   l)
                  layout
              in
              let layout =

--- a/src/interpreter/results.mli
+++ b/src/interpreter/results.mli
@@ -14,7 +14,6 @@ type item_result_layout = {
 }
 
 type flat_item = {
-  flat_name : string;
   value : Variable.t;
   trigger : Variable.t option;
   target : Variable.t;

--- a/src/surface/ast.ml
+++ b/src/surface/ast.ml
@@ -130,7 +130,6 @@ type context =
 
 type operation_decl = {
   op_loc : Pos.t;
-  op_label : string;
   op_default_dest : holder option;
   op_context : context list;
   op_source : holder;
@@ -139,25 +138,10 @@ type operation_decl = {
 }
 
 type ctx_operation_decl = {
-  ctx_op_label : string;
   ctx_op_default_dest : contextualized_variable option;
   ctx_op_source : contextualized_variable;
   ctx_op_guarded_redistrib :
     (contextualized, contextualized redistrib_with_dest list) guarded_redistrib;
-}
-
-type advance_decl = {
-  adv_label : string;
-  adv_output : holder;
-  adv_provider : actor;
-  adv_amount : source formula;
-}
-
-type ctx_advance_decl = {
-  ctx_adv_label : string;
-  ctx_adv_output : contextualized_variable;
-  ctx_adv_provider : contextualized_variable;
-  ctx_adv_amount : contextualized formula;
 }
 
 type event_decl = {
@@ -255,7 +239,6 @@ type _ declaration =
   | DContext : context_decl -> source declaration
   | DInput : input_decl -> source declaration
   | DActor : actor_decl -> source declaration
-  | DHolderAdvance : advance_decl -> source declaration
   | DHolderDefault : default_decl -> source declaration
   | DHolderDeficit : deficit_decl -> source declaration
   | DVarDefault : ctx_default_decl -> contextualized declaration
@@ -328,9 +311,8 @@ let operation_decl
   ?(context = [])
   ~source
   ~guarded_redistrib
-  label = {
+  () = {
   op_loc = loc;
-  op_label = label;
   op_default_dest = default_dest;
   op_context = context;
   op_source = source;

--- a/src/surface/formatAst.ml
+++ b/src/surface/formatAst.ml
@@ -206,15 +206,13 @@ let print_declaration (type a) infos fmt (decl : a declaration) =
         input.input_name
         print_input_context input.input_context)
   | DHolderOperation op ->
-    Format.fprintf fmt "@[<hv 2>operation '%s' %a@,%a%a%a@]"
-      op.op_label
+    Format.fprintf fmt "@[<hv 2>operation %a@,%a%a%a@]"
       (Format.pp_print_option print_destination) op.op_default_dest
       print_op_context op.op_context
       print_op_source op.op_source
       (print_guarded_obj infos print_redistrib_list) op.op_guarded_redistrib
   | DVarOperation op ->
-    Format.fprintf fmt "@[<hv 2>operation '%s' -> %a@,sur %a@;%a@]"
-      op.ctx_op_label
+    Format.fprintf fmt "@[<hv 2>operation -> %a@,sur %a@;%a@]"
       (Format.pp_print_option (ProgramInfo.print_ctx_variable infos)) op.ctx_op_default_dest
       (ProgramInfo.print_ctx_variable infos) op.ctx_op_source
       (print_guarded_obj infos print_redistrib_list) op.ctx_op_guarded_redistrib
@@ -246,11 +244,6 @@ let print_declaration (type a) infos fmt (decl : a declaration) =
       (if v.ctx_val_observable then " observable" else "")
       (ProgramInfo.print_ctx_variable infos) v.ctx_val_var
       (print_formula infos) v.ctx_val_formula
-  | DHolderAdvance a ->
-    Format.fprintf fmt "@[<hov>avance '%s' sur %a par %a@ montant %a@]"
-      a.adv_label print_holder a.adv_output
-      print_actor a.adv_provider
-      (print_formula infos) a.adv_amount
   | DHolderDefault d ->
     Format.fprintf fmt "@[<hv>defaut sur %a@ vers %a@]"
       print_holder d.default_source print_holder d.default_dest

--- a/tests/stablize_input.t
+++ b/tests/stablize_input.t
@@ -178,7 +178,7 @@
        
      ++ after event seuil_100000_entrees :
        - entree_salle_France { 0, 100000 }:
-       - bonus sur le nombre d entrees : 1000000 -> barbie[bonus_nombre_entrees]
+       - flat bonus : 1000000 -> barbie[bonus_nombre_entrees]
        - barbie { 1000000, 15950000 }:
          - barbie[bonus_nombre_entrees] { 1000000, 1000000 }:
          

--- a/tests/sur_un_nuage.t
+++ b/tests/sur_un_nuage.t
@@ -136,7 +136,7 @@
        
      ++ after event seuil_100000_entrees :
        - entree_salle_France { 50000, 150000 }:
-       - bonus sur le nombre d entrees : 1000000 -> barbie[bonus_nombre_entrees]
+       - flat bonus : 1000000 -> barbie[bonus_nombre_entrees]
        - barbie { 1000000, 2340000 }:
          - barbie[bonus_nombre_entrees] { 1000000, 1000000 }:
          


### PR DESCRIPTION
Commit after commit, every needless label has been removed from the compiler. The grammar now parses optional LABELs for the types "operation" and "avance"; the parser.messages file has been regenerated in consequence.

Speaking of which, shouldn't dune be able to automatize that process ? I tried running `dune build @update-parser-messages`, to no avail. Since I used menhir before, I was able to run the appropriate commands by myself, but it was odd for the dune rule to not work.